### PR TITLE
feat: complete Domain layer with aggregates

### DIFF
--- a/src/TrainBooking.Domain/Common/Guards/GuardAgainstNumberExtensions.cs
+++ b/src/TrainBooking.Domain/Common/Guards/GuardAgainstNumberExtensions.cs
@@ -12,23 +12,25 @@ namespace TrainBooking.Domain.Common.Guards;
 public static class GuardAgainstNumberExtensions
 {
     /// <summary>
-    /// Ensures that the provided integer value is greater than zero.
+    /// Ensures that the provided numeric value is greater than zero.
     /// </summary>
-    /// <param name="guardClause">The guard instance used as an entry point for validation.</param>
-    /// <param name="value">The integer value to validate.</param>
+    /// <typeparam name="T">The type of the numeric value.</typeparam>
+    /// <param name="guard">The guard instance used as an entry point for validation.</param>
+    /// <param name="value">The numeric value to validate.</param>
     /// <param name="parameterName">
     /// The name of the parameter being validated. Automatically populated via caller information.
     /// </param>
-    /// <returns>The validated integer value if it is greater than zero.</returns>
+    /// <returns>The validated numeric value if it is greater than zero.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when the value is less than or equal to zero.
     /// </exception>
-    public static int NegativeOrZero(
-        this IGuard guardClause,
-        int value,
+    public static T NegativeOrZero<T>(
+        this IGuard guard,
+        T value,
         [CallerArgumentExpression(nameof(value))] string? parameterName = null)
+        where T : struct, IComparable<T>
     {
-        if (value <= 0)
+        if (value.CompareTo(default) <= 0)
         {
             throw new ArgumentOutOfRangeException(parameterName, value, $"{parameterName} must be greater than zero.");
         }

--- a/src/TrainBooking.Domain/Reservations/DomainEvents/ReservationCancelledDomainEvent.cs
+++ b/src/TrainBooking.Domain/Reservations/DomainEvents/ReservationCancelledDomainEvent.cs
@@ -1,0 +1,8 @@
+using TrainBooking.Domain.Common.DomainEvents;
+
+namespace TrainBooking.Domain.Reservations.DomainEvents;
+
+public sealed record ReservationCancelledDomainEvent(Guid ReservationId) : IDomainEvent
+{
+    public DateTime OccurredAt { get; } = DateTime.UtcNow;
+}

--- a/src/TrainBooking.Domain/Reservations/DomainEvents/ReservationConfirmedDomainEvent.cs
+++ b/src/TrainBooking.Domain/Reservations/DomainEvents/ReservationConfirmedDomainEvent.cs
@@ -1,0 +1,8 @@
+using TrainBooking.Domain.Common.DomainEvents;
+
+namespace TrainBooking.Domain.Reservations.DomainEvents;
+
+public sealed record ReservationConfirmedDomainEvent(Guid ReservationId) : IDomainEvent
+{
+    public DateTime OccurredAt { get; } = DateTime.UtcNow;
+}

--- a/src/TrainBooking.Domain/Reservations/DomainEvents/ReservationCreatedDomainEvent.cs
+++ b/src/TrainBooking.Domain/Reservations/DomainEvents/ReservationCreatedDomainEvent.cs
@@ -1,0 +1,8 @@
+using TrainBooking.Domain.Common.DomainEvents;
+
+namespace TrainBooking.Domain.Reservations.DomainEvents;
+
+public sealed record ReservationCreatedDomainEvent(Guid ReservationId) : IDomainEvent
+{
+    public DateTime OccurredAt { get; } = DateTime.UtcNow;
+}

--- a/src/TrainBooking.Domain/Reservations/DomainEvents/ReservationExpiredDomainEvent.cs
+++ b/src/TrainBooking.Domain/Reservations/DomainEvents/ReservationExpiredDomainEvent.cs
@@ -1,0 +1,8 @@
+using TrainBooking.Domain.Common.DomainEvents;
+
+namespace TrainBooking.Domain.Reservations.DomainEvents;
+
+public sealed record ReservationExpiredDomainEvent(Guid ReservationId) : IDomainEvent
+{
+    public DateTime OccurredAt { get; } = DateTime.UtcNow;
+}

--- a/src/TrainBooking.Domain/Reservations/Enums/ReservationStatus.cs
+++ b/src/TrainBooking.Domain/Reservations/Enums/ReservationStatus.cs
@@ -1,0 +1,9 @@
+namespace TrainBooking.Domain.Reservations.Enums;
+
+public enum ReservationStatus
+{
+    Pending,
+    Confirmed,
+    Cancelled,
+    Expired
+}

--- a/src/TrainBooking.Domain/Reservations/Errors/ReservationErrors.cs
+++ b/src/TrainBooking.Domain/Reservations/Errors/ReservationErrors.cs
@@ -1,0 +1,27 @@
+using TrainBooking.Domain.Common.Results;
+
+namespace TrainBooking.Domain.Reservations.Errors;
+
+public static class ReservationErrors
+{
+    public static Error NoSeatSelected() =>
+        Error.Validation("reservation.no_seat_selected", "No seat selected. At least one seat must be selected.");
+    public static Error TooManySeatsSelected(int seatCount) =>
+        Error.Validation("reservation.too_many_seats_selected", $"Too many seats selected. Seat count: {seatCount}. Maximum allowed is 4.");
+    public static Error TripAlreadyDeparted(DateTime tripDepartureTime) =>
+        Error.Validation("reservation.trip_already_departed", $"Trip has already departed. TripDepartureTime: {tripDepartureTime}.");
+    public static Error CannotConfirmExpired(DateTime expiresAt) =>
+        Error.Conflict("reservation.cannot_confirm_expired", $"Cannot confirm reservation. Reservation expired at: {expiresAt}.");
+    public static Error CannotCancelWithinDepartureWindow(DateTime tripDepartureTime, int requiredHours) =>
+        Error.Conflict("reservation.cannot_cancel_within_departure_window", $"Cannot cancel reservation within {requiredHours} hours of trip departure. TripDepartureTime: {tripDepartureTime}.");
+    public static Error CannotExpireNotYetExpired(DateTime now, DateTime expiresAt) =>
+        Error.Conflict("reservation.cannot_expire_not_yet_expired", $"Cannot expire reservation. Current time: {now}. Reservation expires at: {expiresAt}.");
+    public static Error AlreadyConfirmed() =>
+        Error.Conflict("reservation.already_confirmed", "Reservation has already been confirmed.");
+    public static Error AlreadyCancelled() =>
+        Error.Conflict("reservation.already_cancelled", "Reservation has already been cancelled.");
+    public static Error AlreadyExpired() =>
+        Error.Conflict("reservation.already_expired", "Reservation has already expired.");
+    public static Error ReservationNotPending() =>
+        Error.Validation("reservation.not_pending", "Reservation is not in pending status.");
+}

--- a/src/TrainBooking.Domain/Reservations/Reservation.cs
+++ b/src/TrainBooking.Domain/Reservations/Reservation.cs
@@ -1,0 +1,153 @@
+using TrainBooking.Domain.Common.Entities;
+using TrainBooking.Domain.Common.Guards;
+using TrainBooking.Domain.Common.Results;
+using TrainBooking.Domain.Reservations.DomainEvents;
+using TrainBooking.Domain.Reservations.Enums;
+using TrainBooking.Domain.Reservations.Errors;
+using TrainBooking.Domain.TripSeats;
+
+namespace TrainBooking.Domain.Reservations;
+
+public class Reservation : AggregateRoot
+{
+    public Guid TripId { get; private init; }
+    public Guid UserId { get; private init; }
+    public decimal TotalPrice { get; private init; }
+    public ReservationStatus Status { get; private set; }
+    public DateTime ExpiresAt { get; private init; }
+    public DateTime TripDepartureTime { get; private init; }
+    public DateTime? ConfirmedAt { get; private set; }
+
+    private readonly List<ReservationSeat> _reservationSeats = [];
+    public IReadOnlyCollection<ReservationSeat> ReservationSeats => _reservationSeats.AsReadOnly();
+
+    private Reservation() { }
+    private Reservation(
+        Guid id,
+        Guid tripId,
+        Guid userId,
+        decimal totalPrice,
+        DateTime expiresAt,
+        DateTime tripDepartureTime,
+        IEnumerable<ReservationSeat> reservationSeats) : base(id)
+    {
+        TripId = tripId;
+        UserId = userId;
+        TotalPrice = totalPrice;
+        TripDepartureTime = tripDepartureTime;
+        ExpiresAt = expiresAt;
+        Status = ReservationStatus.Pending;
+
+        _reservationSeats.AddRange(reservationSeats);
+
+        AddDomainEvent(new ReservationCreatedDomainEvent(Id));
+    }
+
+    public static Result<Reservation> Create(
+        Guid tripId,
+        Guid userId,
+        DateTime tripDepartureTime,
+        IReadOnlyCollection<TripSeat> tripSeats,
+        TimeProvider timeProvider)
+    {
+        Guard.Against.Empty(tripId);
+        Guard.Against.Empty(userId);
+        Guard.Against.Null(tripSeats);
+
+        if (tripSeats.Count == 0)
+            return ReservationErrors.NoSeatSelected();
+
+        if (tripSeats.Count > 4)
+            return ReservationErrors.TooManySeatsSelected(tripSeats.Count);
+
+        DateTime now = timeProvider.GetUtcNow().UtcDateTime;
+        if (tripDepartureTime <= now)
+            return ReservationErrors.TripAlreadyDeparted(tripDepartureTime);
+
+        var reservationSeats = new List<ReservationSeat>();
+        DateTime expiresAt = now.AddMinutes(15);
+        decimal totalPrice = tripSeats.Sum(ts => ts.Price);
+        var reservationId = Guid.CreateVersion7();
+
+        foreach (TripSeat tripSeat in tripSeats)
+        {
+            var reservationSeat = ReservationSeat.Create(
+                reservationId,
+                tripSeat.Id,
+                tripSeat.Price);
+            reservationSeats.Add(reservationSeat);
+        }
+
+        return new Reservation(
+            reservationId,
+            tripId,
+            userId,
+            totalPrice,
+            expiresAt,
+            tripDepartureTime,
+            reservationSeats);
+    }
+
+    public Result Confirm(TimeProvider timeProvider)
+    {
+        Result pendingResult = EnsurePending();
+        if (pendingResult.IsFailure)
+            return pendingResult;
+
+        DateTime now = timeProvider.GetUtcNow().UtcDateTime;
+        if (now > ExpiresAt)
+            return ReservationErrors.CannotConfirmExpired(ExpiresAt);
+
+        Status = ReservationStatus.Confirmed;
+        ConfirmedAt = now;
+        AddDomainEvent(new ReservationConfirmedDomainEvent(Id));
+
+        return Result.Success();
+    }
+
+    public Result Cancel(TimeProvider timeProvider)
+    {
+        Result pendingResult = EnsurePending();
+        if (pendingResult.IsFailure)
+            return pendingResult;
+
+        DateTime now = timeProvider.GetUtcNow().UtcDateTime;
+        double hoursUntilDeparture = (TripDepartureTime - now).TotalHours;
+        const int REQUIRED_HOURS = 24;
+        if (hoursUntilDeparture < REQUIRED_HOURS)
+            return ReservationErrors.CannotCancelWithinDepartureWindow(TripDepartureTime, REQUIRED_HOURS);
+
+        Status = ReservationStatus.Cancelled;
+        AddDomainEvent(new ReservationCancelledDomainEvent(Id));
+
+        return Result.Success();
+    }
+
+    public Result Expire(TimeProvider timeProvider)
+    {
+        Result pendingResult = EnsurePending();
+        if (pendingResult.IsFailure)
+            return pendingResult;
+
+        DateTime now = timeProvider.GetUtcNow().UtcDateTime;
+        if (now < ExpiresAt)
+            return ReservationErrors.CannotExpireNotYetExpired(now, ExpiresAt);
+
+        Status = ReservationStatus.Expired;
+        AddDomainEvent(new ReservationExpiredDomainEvent(Id));
+
+        return Result.Success();
+    }
+
+    private Result EnsurePending()
+    {
+        return Status switch
+        {
+            ReservationStatus.Pending => Result.Success(),
+            ReservationStatus.Confirmed => ReservationErrors.AlreadyConfirmed(),
+            ReservationStatus.Cancelled => ReservationErrors.AlreadyCancelled(),
+            ReservationStatus.Expired => ReservationErrors.AlreadyExpired(),
+            _ => throw new InvalidOperationException($"Unknown status: {Status}")
+        };
+    }
+}

--- a/src/TrainBooking.Domain/Reservations/ReservationSeat.cs
+++ b/src/TrainBooking.Domain/Reservations/ReservationSeat.cs
@@ -1,0 +1,39 @@
+using TrainBooking.Domain.Common.Entities;
+using TrainBooking.Domain.Common.Guards;
+
+namespace TrainBooking.Domain.Reservations;
+
+public class ReservationSeat : EntityBase
+{
+    public Guid ReservationId { get; private init; }
+    public Guid TripSeatId { get; private init; }
+    public decimal PriceSnapshot { get; private init; }
+
+    private ReservationSeat() { }
+    private ReservationSeat(
+        Guid id,
+        Guid reservationId,
+        Guid tripSeatId,
+        decimal priceSnapshot) : base(id)
+    {
+        ReservationId = reservationId;
+        TripSeatId = tripSeatId;
+        PriceSnapshot = priceSnapshot;
+    }
+
+    internal static ReservationSeat Create(
+        Guid reservationId,
+        Guid tripSeatId,
+        decimal priceSnapshot)
+    {
+        Guard.Against.Empty(reservationId);
+        Guard.Against.Empty(tripSeatId);
+        Guard.Against.NegativeOrZero(priceSnapshot);
+
+        return new ReservationSeat(
+            Guid.CreateVersion7(),
+            reservationId,
+            tripSeatId,
+            priceSnapshot);
+    }
+}

--- a/src/TrainBooking.Domain/TrainBooking.Domain.csproj
+++ b/src/TrainBooking.Domain/TrainBooking.Domain.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Users\" />
     <Folder Include="Trips\" />
     <Folder Include="TripSeats\" />
     <Folder Include="Reservations\" />

--- a/src/TrainBooking.Domain/TrainBooking.Domain.csproj
+++ b/src/TrainBooking.Domain/TrainBooking.Domain.csproj
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Trips\" />
-    <Folder Include="TripSeats\" />
     <Folder Include="Reservations\" />
   </ItemGroup>
 

--- a/src/TrainBooking.Domain/TrainBooking.Domain.csproj
+++ b/src/TrainBooking.Domain/TrainBooking.Domain.csproj
@@ -6,8 +6,4 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Folder Include="Reservations\" />
-  </ItemGroup>
-
 </Project>

--- a/src/TrainBooking.Domain/TripSeats/DomainEvents/TripSeatReleasedDomainEvent.cs
+++ b/src/TrainBooking.Domain/TripSeats/DomainEvents/TripSeatReleasedDomainEvent.cs
@@ -1,0 +1,8 @@
+using TrainBooking.Domain.Common.DomainEvents;
+
+namespace TrainBooking.Domain.TripSeats.DomainEvents;
+
+public sealed record TripSeatReleasedDomainEvent(Guid TripSeatId) : IDomainEvent
+{
+    public DateTime OccurredAt { get; } = DateTime.UtcNow;
+}

--- a/src/TrainBooking.Domain/TripSeats/DomainEvents/TripSeatReservedDomainEvent.cs
+++ b/src/TrainBooking.Domain/TripSeats/DomainEvents/TripSeatReservedDomainEvent.cs
@@ -1,0 +1,8 @@
+using TrainBooking.Domain.Common.DomainEvents;
+
+namespace TrainBooking.Domain.TripSeats.DomainEvents;
+
+public sealed record TripSeatReservedDomainEvent(Guid TripSeatId) : IDomainEvent
+{
+    public DateTime OccurredAt { get; } = DateTime.UtcNow;
+}

--- a/src/TrainBooking.Domain/TripSeats/Enums/TripSeatStatus.cs
+++ b/src/TrainBooking.Domain/TripSeats/Enums/TripSeatStatus.cs
@@ -1,0 +1,8 @@
+namespace TrainBooking.Domain.TripSeats.Enums;
+
+public enum TripSeatStatus
+{
+    Available,
+    Reserved,
+    Sold
+}

--- a/src/TrainBooking.Domain/TripSeats/Errors/TripSeatErrors.cs
+++ b/src/TrainBooking.Domain/TripSeats/Errors/TripSeatErrors.cs
@@ -1,0 +1,13 @@
+using TrainBooking.Domain.Common.Results;
+
+namespace TrainBooking.Domain.TripSeats.Errors;
+
+public static class TripSeatErrors
+{
+    public static Error AlreadyReserved(Guid tripSeatId) =>
+        Error.Conflict("trip_seat.already_reserved", $"Seat number {tripSeatId} is already reserved.");
+    public static Error AlreadySold(Guid tripSeatId) =>
+        Error.Conflict("trip_seat.already_sold", $"Seat number {tripSeatId} is already sold.");
+    public static Error NotReserved(Guid tripSeatId) =>
+        Error.Conflict("trip_seat.not_reserved", $"Seat number {tripSeatId} is not reserved.");
+}

--- a/src/TrainBooking.Domain/TripSeats/TripSeat.cs
+++ b/src/TrainBooking.Domain/TripSeats/TripSeat.cs
@@ -1,0 +1,94 @@
+using TrainBooking.Domain.Common.Entities;
+using TrainBooking.Domain.Common.Guards;
+using TrainBooking.Domain.Common.Results;
+using TrainBooking.Domain.TripSeats.DomainEvents;
+using TrainBooking.Domain.TripSeats.Enums;
+using TrainBooking.Domain.TripSeats.Errors;
+
+namespace TrainBooking.Domain.TripSeats;
+
+public class TripSeat : AggregateRoot
+{
+    public Guid TripId { get; private init; }
+    public Guid SeatId { get; private init; }
+    public TripSeatStatus Status { get; private set; }
+    public decimal Price { get; private init; }
+
+    private TripSeat() { }
+    private TripSeat(
+        Guid id,
+        Guid tripId,
+        Guid seatId,
+        decimal price) : base(id)
+    {
+        TripId = tripId;
+        SeatId = seatId;
+        Price = price;
+
+        Status = TripSeatStatus.Available;
+    }
+
+    public static TripSeat Create(
+        Guid tripId,
+        Guid seatId,
+        decimal price)
+    {
+        Guard.Against.Empty(tripId);
+        Guard.Against.Empty(seatId);
+        Guard.Against.NegativeOrZero(price);
+
+        return new TripSeat(
+            Guid.CreateVersion7(),
+            tripId,
+            seatId,
+            price);
+    }
+
+    public Result Reserve()
+    {
+        Result checkResult = CheckAlreadySold();
+        if (checkResult.IsFailure)
+            return checkResult;
+
+        if (Status != TripSeatStatus.Available)
+            return TripSeatErrors.AlreadyReserved(Id);
+
+        Status = TripSeatStatus.Reserved;
+        AddDomainEvent(new TripSeatReservedDomainEvent(Id));
+        return Result.Success();
+    }
+
+    public Result Release()
+    {
+        Result checkResult = CheckAlreadySold();
+        if (checkResult.IsFailure)
+            return checkResult;
+
+        if (Status != TripSeatStatus.Reserved)
+            return TripSeatErrors.NotReserved(Id);
+
+        Status = TripSeatStatus.Available;
+        AddDomainEvent(new TripSeatReleasedDomainEvent(Id));
+        return Result.Success();
+    }
+
+    public Result MarkAsSold()
+    {
+        Result checkResult = CheckAlreadySold();
+        if (checkResult.IsFailure)
+            return checkResult;
+
+        if (Status != TripSeatStatus.Reserved)
+            return TripSeatErrors.NotReserved(Id);
+
+        Status = TripSeatStatus.Sold;
+        return Result.Success();
+    }
+
+    private Result CheckAlreadySold()
+    {
+        if (Status == TripSeatStatus.Sold)
+            return TripSeatErrors.AlreadySold(Id);
+        return Result.Success();
+    }
+}

--- a/src/TrainBooking.Domain/Trips/DomainEvent/TripCreatedDomainEvent.cs
+++ b/src/TrainBooking.Domain/Trips/DomainEvent/TripCreatedDomainEvent.cs
@@ -1,0 +1,8 @@
+using TrainBooking.Domain.Common.DomainEvents;
+
+namespace TrainBooking.Domain.Trips.DomainEvent;
+
+public sealed record TripCreatedDomainEvent(Guid TripId) : IDomainEvent
+{
+    public DateTime OccurredAt { get; } = DateTime.UtcNow;
+}

--- a/src/TrainBooking.Domain/Trips/Errors/TripErrors.cs
+++ b/src/TrainBooking.Domain/Trips/Errors/TripErrors.cs
@@ -1,0 +1,15 @@
+using TrainBooking.Domain.Common.Results;
+
+namespace TrainBooking.Domain.Trips.Errors;
+
+public static class TripErrors
+{
+    public static Error InvalidTimeRange(DateTime departureTime, DateTime arrivalTime) =>
+        Error.Validation("trip.invalid_time_range", $"Departure time ({departureTime}) must be before arrival time ({arrivalTime}).");
+
+    public static Error SameOriginAndDestination() =>
+        Error.Validation("trip.same_origin_destination", "Origin and destination stations cannot be the same.");
+
+    public static Error DepartureTimeInPast(DateTime departureTime) =>
+        Error.Validation("trip.departure_time_in_past", $"Departure time ({departureTime}) cannot be in the past.");
+}

--- a/src/TrainBooking.Domain/Trips/Trip.cs
+++ b/src/TrainBooking.Domain/Trips/Trip.cs
@@ -1,0 +1,63 @@
+using TrainBooking.Domain.Common.Entities;
+using TrainBooking.Domain.Common.Guards;
+using TrainBooking.Domain.Common.Results;
+using TrainBooking.Domain.Trips.DomainEvent;
+using TrainBooking.Domain.Trips.Errors;
+
+namespace TrainBooking.Domain.Trips;
+
+public class Trip : AggregateRoot
+{
+    public Guid TrainId { get; private init; }
+    public string OriginStation { get; private init; } = string.Empty;
+    public string DestinationStation { get; private init; } = string.Empty;
+    public DateTime DepartureTime { get; private init; }
+    public DateTime ArrivalTime { get; private init; }
+
+    private Trip() { }
+    private Trip(
+        Guid id,
+        Guid trainId,
+        string originStation,
+        string destinationStation,
+        DateTime departureTime,
+        DateTime arrivalTime) : base(id)
+    {
+        TrainId = trainId;
+        OriginStation = originStation;
+        DestinationStation = destinationStation;
+        DepartureTime = departureTime;
+        ArrivalTime = arrivalTime;
+        AddDomainEvent(new TripCreatedDomainEvent(id));
+    }
+
+    public static Result<Trip> Create(
+        Guid trainId,
+        string originStation,
+        string destinationStation,
+        DateTime departureTime,
+        DateTime arrivalTime,
+        TimeProvider timeProvider)
+    {
+        Guard.Against.Empty(trainId);
+        Guard.Against.NullOrWhiteSpace(originStation);
+        Guard.Against.NullOrWhiteSpace(destinationStation);
+
+        if (departureTime >= arrivalTime)
+            return TripErrors.InvalidTimeRange(departureTime, arrivalTime);
+
+        if (originStation == destinationStation)
+            return TripErrors.SameOriginAndDestination();
+
+        if (departureTime < timeProvider.GetUtcNow().UtcDateTime)
+            return TripErrors.DepartureTimeInPast(departureTime);
+
+        return new Trip(
+            Guid.CreateVersion7(),
+            trainId,
+            originStation,
+            destinationStation,
+            departureTime,
+            arrivalTime);
+    }
+}

--- a/src/TrainBooking.Domain/Users/DomainEvents/UserCreatedDomainEvent.cs
+++ b/src/TrainBooking.Domain/Users/DomainEvents/UserCreatedDomainEvent.cs
@@ -1,0 +1,9 @@
+using TrainBooking.Domain.Common.DomainEvents;
+
+namespace TrainBooking.Domain.Users.DomainEvents;
+
+public sealed record UserCreatedDomainEvent(
+    Guid UserId) : IDomainEvent
+{
+    public DateTime OccurredAt { get; } = DateTime.UtcNow;
+}

--- a/src/TrainBooking.Domain/Users/DomainEvents/UserProfileUpdatedDomainEvent.cs
+++ b/src/TrainBooking.Domain/Users/DomainEvents/UserProfileUpdatedDomainEvent.cs
@@ -1,0 +1,9 @@
+using TrainBooking.Domain.Common.DomainEvents;
+
+namespace TrainBooking.Domain.Users.DomainEvents;
+
+public sealed record UserProfileUpdatedDomainEvent(
+    Guid UserId) : IDomainEvent
+{
+    public DateTime OccurredAt { get; } = DateTime.UtcNow;
+}

--- a/src/TrainBooking.Domain/Users/Errors/UserErrors.cs
+++ b/src/TrainBooking.Domain/Users/Errors/UserErrors.cs
@@ -1,0 +1,11 @@
+using TrainBooking.Domain.Common.Results;
+
+namespace TrainBooking.Domain.Users.Errors;
+
+public static class UserErrors
+{
+    public static Error DuplicateEmail(string email) =>
+            Error.Conflict("user.duplicate_email", $"User with email {email} already exists.");
+    public static Error InvalidEmailFormat(string email) =>
+            Error.Validation("user.invalid_email_format", $"Email {email} is not in a valid format.");
+}

--- a/src/TrainBooking.Domain/Users/User.cs
+++ b/src/TrainBooking.Domain/Users/User.cs
@@ -1,0 +1,66 @@
+using TrainBooking.Domain.Common.Entities;
+using TrainBooking.Domain.Common.Guards;
+using TrainBooking.Domain.Common.Results;
+using TrainBooking.Domain.Users.DomainEvents;
+using TrainBooking.Domain.Users.Errors;
+
+namespace TrainBooking.Domain.Users;
+
+public class User : AggregateRoot
+{
+    public string Auth0Sub { get; private init; } = default!;
+    public string Email { get; private set; } = default!;
+    public string? FullName { get; private set; }
+    public DateTime LastSyncedAt { get; private set; }
+
+    private User() { }
+    private User(
+        Guid userId,
+        string auth0Sub,
+        string email,
+        string? fullName) : base(userId)
+    {
+        Auth0Sub = auth0Sub;
+        Email = email;
+        FullName = fullName;
+        LastSyncedAt = DateTime.UtcNow;
+
+        AddDomainEvent(new UserCreatedDomainEvent(Id));
+    }
+
+    public static User Create(
+        string auth0Sub,
+        string email,
+        string? fullName)
+    {
+        Guard.Against.NullOrWhiteSpace(email);
+        Guard.Against.NullOrWhiteSpace(auth0Sub);
+
+        return new User(Guid.CreateVersion7(), auth0Sub, email, fullName);
+    }
+
+    public Result UpdateProfile(
+        string email,
+        string? fullName)
+    {
+        Guard.Against.NullOrWhiteSpace(email);
+        if (!IsValidEmailFormat(email))
+            return UserErrors.InvalidEmailFormat(email);
+
+        bool emailNotChanged = Email == email;
+        bool fullNameNotChanged = FullName == fullName;
+        if (emailNotChanged && fullNameNotChanged)
+            return Result.Success();
+
+        Email = email;
+        FullName = fullName;
+        LastSyncedAt = DateTime.UtcNow;
+        
+        AddDomainEvent(new UserProfileUpdatedDomainEvent(Id));
+        return Result.Success();
+    }
+
+    // This method checks if the email format is valid. (simple check for '@' and length >= 3)
+    private static bool IsValidEmailFormat(string email) =>
+        email.Contains('@') && email.Length >= 3;
+}

--- a/src/TrainBooking.Domain/Users/User.cs
+++ b/src/TrainBooking.Domain/Users/User.cs
@@ -55,7 +55,7 @@ public class User : AggregateRoot
         Email = email;
         FullName = fullName;
         LastSyncedAt = DateTime.UtcNow;
-        
+
         AddDomainEvent(new UserProfileUpdatedDomainEvent(Id));
         return Result.Success();
     }


### PR DESCRIPTION
<h2>Summary</h2>
<p>Implements the full Domain layer for the Train Seat Reservation API. Seven aggregates cover the entire business domain — physical fleet (trains, wagons, seats), trips, per-trip seat availability, users (cached from Auth0), and reservations.</p>
<p>The layer is dependency-free: no MediatR, no EF Core, no FluentValidation. Adapters to those libraries live in Application and Infrastructure. This makes the domain trivially unit-testable, portable, and stable across infrastructure changes.</p>
<h2>What's included</h2>
<h3>Aggregates</h3>

Aggregate | Internal entities | Domain events
-- | -- | --
Train | Wagon, Seat | TrainCreatedDomainEvent
User | — | UserCreatedDomainEvent, UserProfileUpdatedDomainEvent
Trip | — | TripCreatedDomainEvent
TripSeat | — | TripSeatReservedDomainEvent, TripSeatReleasedDomainEvent
Reservation | ReservationSeat | ReservationCreatedDomainEvent, ReservationConfirmedDomainEvent, ReservationCancelledDomainEvent, ReservationExpiredDomainEvent
<h2>What's not in this PR</h2>
<ul>
<li><strong>EF Core configurations and migrations</strong> — Infrastructure layer, next PR.</li>
<li><strong>MediatR adapter (<code>DomainEventNotification&lt;T&gt;</code>) and dispatch in <code>SaveChangesAsync</code></strong> — Application + Infrastructure.</li>
<li><strong>Repositories implementations</strong> — Infrastructure.</li>
<li><strong>Architecture tests via NetArchTest</strong> — separate test PR; the relevant rules will pin "Domain depends on nothing external" and similar invariants.</li>
<li><strong>Unit tests</strong> — separate PR after the API stabilizes (no premature commitment to a specific public surface yet).</li>
</ul>
<h2>Known tech debt and follow-ups</h2>
<ol>
<li><strong><code>User</code> still uses <code>DateTime.UtcNow</code> directly</strong> instead of <code>TimeProvider</code>. Migration to TimeProvider is on the backlog; doesn't affect business correctness, only test determinism.</li>
<li><strong><code>string.Empty</code> vs <code>null!</code> initialization</strong> is inconsistent across <code>Train</code>, <code>Trip</code>, and other aggregates. A small refactor PR to standardize on <code>null!</code> is on the backlog.</li>
<li><strong><code>EntityBase</code> audit fields (<code>CreatedAt</code>, <code>UpdatedAt</code>) use <code>DateTime.UtcNow</code></strong> at construction. Same TimeProvider story — moves with item 1.</li>
<li><strong>No <code>IClock</code>-style abstraction in Domain itself</strong> — we depend on <code>System.TimeProvider</code> directly. This is a deliberate trade-off (BCL is not a library), but worth noting for purist readers.</li>
</ol>
<h2>Testing</h2>
<ul>
<li><code>dotnet build --configuration Release</code> passes for all projects.</li>
<li>No runtime smoke test yet (Infrastructure not in place); aggregate construction was verified manually via console snippets during development.</li>
<li>Architecture tests will pin the dependency rules in a follow-up PR.</li>
</ul>
<h2>Reviewer notes</h2>
<p>This is a large PR by line count, but each aggregate follows the same pattern (factory + private constructors + guards + Result-returning mutations + domain events). Once you've reviewed <code>Train</code> + <code>Reservation</code>, the rest are variations on the theme.</p>
<p>The most interesting files to look at, in order:</p>
<ol>
<li><code>Common/Entities/AggregateRoot.cs</code> — the foundation everything builds on.</li>
<li><code>Common/Results/Result.cs</code> and <code>Error.cs</code> — the error model.</li>
<li><code>Reservations/Reservation.cs</code> — the most complex aggregate (4 status transitions, time-window invariant, denormalized fields, internal collection management).</li>
<li><code>Trains/Train.cs</code> + <code>Wagon.cs</code> + <code>Seat.cs</code> — the three-level aggregate with strict access control between layers.</li>
<li><code>TripSeats/TripSeat.cs</code> — concise aggregate showing the status-transition pattern that <code>Reservation</code> then expands.</li>
</ol></body></html><!--EndFragment-->
</body>
</html><html>
<body>
<!--StartFragment--><html><head></head><body><h1>feat(domain): complete Domain layer with 7 aggregates</h1>
<h2>Summary</h2>
<p>Implements the full Domain layer for the Train Seat Reservation API. Seven aggregates cover the entire business domain — physical fleet (trains, wagons, seats), trips, per-trip seat availability, users (cached from Auth0), and reservations.</p>
<p>The layer is dependency-free: no MediatR, no EF Core, no FluentValidation. Adapters to those libraries live in Application and Infrastructure. This makes the domain trivially unit-testable, portable, and stable across infrastructure changes.</p>
<h2>What's included</h2>
<h3>Aggregates</h3>

Aggregate | Internal entities | Domain events
-- | -- | --
Train | Wagon, Seat | TrainCreatedDomainEvent
User | — | UserCreatedDomainEvent, UserProfileUpdatedDomainEvent
Trip | — | TripCreatedDomainEvent
TripSeat | — | TripSeatReservedDomainEvent, TripSeatReleasedDomainEvent
Reservation | ReservationSeat | ReservationCreatedDomainEvent, ReservationConfirmedDomainEvent, ReservationCancelledDomainEvent, ReservationExpiredDomainEvent
<h2>What's not in this PR</h2>
<ul>
<li><strong>EF Core configurations and migrations</strong> — Infrastructure layer, next PR.</li>
<li><strong>MediatR adapter (<code>DomainEventNotification&lt;T&gt;</code>) and dispatch in <code>SaveChangesAsync</code></strong> — Application + Infrastructure.</li>
<li><strong>Repositories implementations</strong> — Infrastructure.</li>
<li><strong>Architecture tests via NetArchTest</strong> — separate test PR; the relevant rules will pin "Domain depends on nothing external" and similar invariants.</li>
<li><strong>Unit tests</strong> — separate PR after the API stabilizes (no premature commitment to a specific public surface yet).</li>
</ul>
<h2>Known tech debt and follow-ups</h2>
<ol>
<li><strong><code>User</code> still uses <code>DateTime.UtcNow</code> directly</strong> instead of <code>TimeProvider</code>. Migration to TimeProvider is on the backlog; doesn't affect business correctness, only test determinism.</li>
<li><strong><code>string.Empty</code> vs <code>null!</code> initialization</strong> is inconsistent across <code>Train</code>, <code>Trip</code>, and other aggregates. A small refactor PR to standardize on <code>null!</code> is on the backlog.</li>
<li><strong><code>EntityBase</code> audit fields (<code>CreatedAt</code>, <code>UpdatedAt</code>) use <code>DateTime.UtcNow</code></strong> at construction. Same TimeProvider story — moves with item 1.</li>
<li><strong>No <code>IClock</code>-style abstraction in Domain itself</strong> — we depend on <code>System.TimeProvider</code> directly. This is a deliberate trade-off (BCL is not a library), but worth noting for purist readers.</li>
</ol>
<h2>Testing</h2>
<ul>
<li><code>dotnet build --configuration Release</code> passes for all projects.</li>
<li>No runtime smoke test yet (Infrastructure not in place); aggregate construction was verified manually via console snippets during development.</li>
<li>Architecture tests will pin the dependency rules in a follow-up PR.</li>
</ul>
<h2>Reviewer notes</h2>
<p>This is a large PR by line count, but each aggregate follows the same pattern (factory + private constructors + guards + Result-returning mutations + domain events). Once you've reviewed <code>Train</code> + <code>Reservation</code>, the rest are variations on the theme.</p>
<p>The most interesting files to look at, in order:</p>
<ol>
<li><code>Common/Entities/AggregateRoot.cs</code> — the foundation everything builds on.</li>
<li><code>Common/Results/Result.cs</code> and <code>Error.cs</code> — the error model.</li>
<li><code>Reservations/Reservation.cs</code> — the most complex aggregate (4 status transitions, time-window invariant, denormalized fields, internal collection management).</li>
<li><code>Trains/Train.cs</code> + <code>Wagon.cs</code> + <code>Seat.cs</code> — the three-level aggregate with strict access control between layers.</li>
<li><code>TripSeats/TripSeat.cs</code> — concise aggregate showing the status-transition pattern that <code>Reservation</code> then expands.</li>
</ol></body></html><!--EndFragment-->
</body>
</html>