### PR TITLE
feat: infrastructure bootstrap EF Core wiring

### DIFF
--- a/TrainBooking.Hosting/Application.cs
+++ b/TrainBooking.Hosting/Application.cs
@@ -1,0 +1,7 @@
+
+namespace TrainBooking.Hosting;
+
+public static class Application
+{
+    public static IHostBuilder CreateBuilder(string[] args) => RegisterDefaults(args);
+}

--- a/TrainBooking.Hosting/TrainBooking.Hosting.csproj
+++ b/TrainBooking.Hosting/TrainBooking.Hosting.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/TrainBooking.Hosting/Worker.cs
+++ b/TrainBooking.Hosting/Worker.cs
@@ -1,0 +1,11 @@
+namespace TrainBooking.Hosting;
+
+public static class Worker
+{
+    public static IHostBuilder CreateBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureServices((hostContext, services) =>
+            {
+                services.AddHostedService<WorkerService>();
+            });)
+}

--- a/TrainBooking.slnx
+++ b/TrainBooking.slnx
@@ -1,10 +1,18 @@
 <Solution>
   <Folder Name="/src/">
-    <Project Path="src/TrainBooking.Api/TrainBooking.Api.csproj" />
+    <Project Path="src/TrainBooking.Api/TrainBooking.Api.csproj">
+      <BuildDependency Project="src/TrainBooking.Application/TrainBooking.Application.csproj" />
+      <BuildDependency Project="src/TrainBooking.Infrastructure/TrainBooking.Infrastructure.csproj" />
+    </Project>
     <Project Path="src/TrainBooking.Application/TrainBooking.Application.csproj" />
     <Project Path="src/TrainBooking.Domain/TrainBooking.Domain.csproj" />
-    <Project Path="src/TrainBooking.Infrastructure/TrainBooking.Infrastructure.csproj" />
-    <Project Path="src/TrainBooking.Migrations/TrainBooking.Migrations.csproj" />
+    <Project Path="src/TrainBooking.Infrastructure/TrainBooking.Infrastructure.csproj">
+      <BuildDependency Project="src/TrainBooking.Application/TrainBooking.Application.csproj" />
+      <BuildDependency Project="src/TrainBooking.Domain/TrainBooking.Domain.csproj" />
+    </Project>
+    <Project Path="src/TrainBooking.Migrations/TrainBooking.Migrations.csproj">
+      <BuildDependency Project="src/TrainBooking.Infrastructure/TrainBooking.Infrastructure.csproj" />
+    </Project>
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/TrainBooking.Tests/TrainBooking.Tests.csproj" />

--- a/src/TrainBooking.Api/Program.cs
+++ b/src/TrainBooking.Api/Program.cs
@@ -1,10 +1,13 @@
+using TrainBooking.Infrastructure;
+
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
 builder.Services.AddControllers();
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+
+builder.Services.AddInfrastructure(builder.Configuration);
 
 WebApplication app = builder.Build();
 

--- a/src/TrainBooking.Api/TrainBooking.Api.csproj
+++ b/src/TrainBooking.Api/TrainBooking.Api.csproj
@@ -21,4 +21,9 @@
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\TrainBooking.Infrastructure\TrainBooking.Infrastructure.csproj" />
+    <ProjectReference Include="..\TrainBooking.Application\TrainBooking.Application.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/TrainBooking.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/src/TrainBooking.Infrastructure/InfrastructureServiceExtensions.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using TrainBooking.Infrastructure.Persistence;
+
+namespace TrainBooking.Infrastructure;
+
+public static class InfrastructureServiceExtensions
+{
+    public static IServiceCollection AddInfrastructure(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        string connectionString = configuration.GetConnectionString("DefaultConnection")
+            ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
+        services.AddDbContext<AppDbContext>(options =>
+            options.UseSqlServer(connectionString));
+        return services;
+    }
+
+}

--- a/src/TrainBooking.Infrastructure/Persistence/AppDbContext.cs
+++ b/src/TrainBooking.Infrastructure/Persistence/AppDbContext.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TrainBooking.Domain.Common.Entities;
+using TrainBooking.Domain.Reservations;
+using TrainBooking.Domain.Trains;
+using TrainBooking.Domain.Trips;
+using TrainBooking.Domain.TripSeats;
+using TrainBooking.Domain.Users;
+
+namespace TrainBooking.Infrastructure.Persistence;
+
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options)
+    : DbContext(options)
+{
+    public DbSet<Reservation> Reservations { get; set; }
+    public DbSet<Train> Trains { get; set; }
+    public DbSet<Trip> Trips { get; set; }
+    public DbSet<TripSeat> TripSeats { get; set; }
+    public DbSet<User> Users { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+
+        // Retrieve all aggregate types from the model and configure their properties
+        IEnumerable<Type> aggregateTypes = modelBuilder.Model
+            .GetEntityTypes()
+            .Select(e => e.ClrType)
+            .Where(t => !t.IsAbstract && t.IsAssignableTo(typeof(AggregateRoot)));
+
+        // Configure properties of aggregates. Traverse the aggregate tree, ignore DomainEvents and configure Id as ValueGeneratedNever
+        foreach (Type aggregateType in aggregateTypes)
+        {
+            EntityTypeBuilder aggregateTypeBuilder = modelBuilder.Entity(aggregateType);
+            aggregateTypeBuilder.Ignore(nameof(AggregateRoot.DomainEvents));
+            aggregateTypeBuilder.Property(nameof(AggregateRoot.Id)).ValueGeneratedNever();
+        }
+    }
+}

--- a/src/TrainBooking.Infrastructure/TrainBooking.Infrastructure.csproj
+++ b/src/TrainBooking.Infrastructure/TrainBooking.Infrastructure.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.7" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\TrainBooking.Domain\TrainBooking.Domain.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/TrainBooking.Migrations/Program.cs
+++ b/src/TrainBooking.Migrations/Program.cs
@@ -1,5 +1,29 @@
-// Migrations runner — will apply EF Core migrations to the database.
-// TODO: implement once the first migration is generated.
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TrainBooking.Infrastructure;
+using TrainBooking.Infrastructure.Persistence;
 
-Console.WriteLine("Migrations runner — not implemented yet.");
-return 0;
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddInfrastructure(builder.Configuration);
+
+using IHost host = builder.Build();
+
+using IServiceScope scope = host.Services.CreateScope();
+ILogger<Program> logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+AppDbContext dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+try
+{
+    logger.LogInformation("Applying migrations...");
+    await dbContext.Database.MigrateAsync();
+    logger.LogInformation("Migrations applied successfully.");
+    return 0;
+}
+catch (Exception ex)
+{
+    logger.LogError(ex, "Failed to apply migrations.");
+    return 1;
+}

--- a/src/TrainBooking.Migrations/TrainBooking.Migrations.csproj
+++ b/src/TrainBooking.Migrations/TrainBooking.Migrations.csproj
@@ -12,6 +12,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TrainBooking.Infrastructure\TrainBooking.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/TrainBooking.Migrations/appsettings.json
+++ b/src/TrainBooking.Migrations/appsettings.json
@@ -1,0 +1,7 @@
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Sets up the Infrastructure layer skeleton: `AppDbContext`, DI extension method, and a console runner for migrations. No entity configurations or migrations yet - those come in the next PR.

## What's included

* **`AppDbContext`** - `DbSet<T>` for every aggregate root (Train, User, Trip, TripSeat, Reservation). `OnModelCreating` calls `ApplyConfigurationsFromAssembly` and runs a reflection loop over `AggregateRoot` descendants to `Ignore(DomainEvents)` and set `Id` to `ValueGeneratedNever`. Internal entities (Wagon, Seat, ReservationSeat) are deliberately not exposed as `DbSet` - they're reachable only through their roots.
* **`DependencyInjection.AddInfrastructure(IServiceCollection, IConfiguration)`** - registers `AppDbContext` with `UseSqlServer`. Throws on a missing `DefaultConnection` connection string for fail-fast diagnostics.
* **`TrainBooking.Migrations` runner** - top-level `Program.cs` that builds a host, opens a scope, calls `Database.MigrateAsync()`, and exits with code 0 on success or 1 on failure. Logs each step via `ILogger`.
* **API wiring** - `builder.Services.AddInfrastructure(builder.Configuration)` added to `TrainBooking.Api/Program.cs`.
* **Local secrets** - connection string lives in User Secrets (`dotnet user-secrets`), not in committed files. `appsettings.Development.json` stays clean.

## What's not in this PR

* `IEntityTypeConfiguration<T>` for any entity - next PR (`feat/ef-core-configurations`)
* Value converters (e.g., for `SeatClass`) - next PR
* Initial migration (`dotnet ef migrations add InitialCreate`) - next PR
* Repositories and `IUnitOfWork` - separate PR after configurations
* Domain-event dispatch via `SaveChangesInterceptor` - separate PR

## Testing

* `dotnet build --configuration Release` passes.
* `docker compose up -d` starts SQL Server 2022 and Redis.
* `dotnet run --project src/TrainBooking.Migrations` connects, finds zero migrations to apply, exits 0. Creates only the `__EFMigrationsHistory` table - actual schema arrives in the next PR.
* `dotnet run --project src/TrainBooking.Api` starts without errors.