### PR TITLE
feat: add core repositories

### DIFF
--- a/src/TrainBooking.Application/Abstractions/Repositories/IReservationRepository.cs
+++ b/src/TrainBooking.Application/Abstractions/Repositories/IReservationRepository.cs
@@ -1,0 +1,11 @@
+using TrainBooking.Domain.Reservations;
+
+namespace TrainBooking.Application.Abstractions.Repositories;
+
+public interface IReservationRepository
+{
+    Task<Reservation?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<int> CountActiveByUserOnTripAsync(Guid userId, Guid tripId, CancellationToken ct = default);
+    Task<IReadOnlyList<Reservation>> GetExpiredPendingAsync(DateTime now, CancellationToken ct = default);
+    Task AddAsync(Reservation reservation, CancellationToken ct = default);
+}

--- a/src/TrainBooking.Application/Abstractions/Repositories/ITrainRepository.cs
+++ b/src/TrainBooking.Application/Abstractions/Repositories/ITrainRepository.cs
@@ -1,0 +1,9 @@
+using TrainBooking.Domain.Trains;
+
+namespace TrainBooking.Application.Abstractions.Repositories;
+
+public interface ITrainRepository
+{
+    Task<Train?> GetByIdWithFullStructureAsync(Guid id, CancellationToken ct = default);
+    Task AddAsync(Train train, CancellationToken ct = default);
+}

--- a/src/TrainBooking.Application/Abstractions/Repositories/ITripRepository.cs
+++ b/src/TrainBooking.Application/Abstractions/Repositories/ITripRepository.cs
@@ -1,0 +1,9 @@
+using TrainBooking.Domain.Trips;
+
+namespace TrainBooking.Application.Abstractions.Repositories;
+
+public interface ITripRepository
+{
+    Task<Trip?> GetByIdAsync(Guid Id, CancellationToken ct = default);
+    Task AddAsync(Trip Trip, CancellationToken ct = default);
+}

--- a/src/TrainBooking.Application/Abstractions/Repositories/ITripRepository.cs
+++ b/src/TrainBooking.Application/Abstractions/Repositories/ITripRepository.cs
@@ -4,6 +4,6 @@ namespace TrainBooking.Application.Abstractions.Repositories;
 
 public interface ITripRepository
 {
-    Task<Trip?> GetByIdAsync(Guid Id, CancellationToken ct = default);
-    Task AddAsync(Trip Trip, CancellationToken ct = default);
+    Task<Trip?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task AddAsync(Trip trip, CancellationToken ct = default);
 }

--- a/src/TrainBooking.Application/Abstractions/Repositories/ITripSeatRepository.cs
+++ b/src/TrainBooking.Application/Abstractions/Repositories/ITripSeatRepository.cs
@@ -1,0 +1,10 @@
+using TrainBooking.Domain.TripSeats;
+
+namespace TrainBooking.Application.Abstractions.Repositories;
+
+public interface ITripSeatRepository
+{
+    Task<IReadOnlyList<TripSeat>> GetByTripIdAsync(Guid tripId, CancellationToken ct = default);
+    Task<IReadOnlyList<TripSeat>> LockByIdsAsync(IReadOnlyCollection<Guid> tripSeatIds, CancellationToken ct = default);
+    Task AddRangeAsync(IEnumerable<TripSeat> tripSeats, CancellationToken ct = default);
+}

--- a/src/TrainBooking.Application/Abstractions/Repositories/IUnitOfWork.cs
+++ b/src/TrainBooking.Application/Abstractions/Repositories/IUnitOfWork.cs
@@ -1,0 +1,6 @@
+namespace TrainBooking.Application.Abstractions.Repositories;
+
+public interface IUnitOfWork
+{
+    Task<int> CommitAsync(CancellationToken ct = default);
+}

--- a/src/TrainBooking.Application/Abstractions/Repositories/IUserRepository.cs
+++ b/src/TrainBooking.Application/Abstractions/Repositories/IUserRepository.cs
@@ -1,0 +1,10 @@
+using TrainBooking.Domain.Users;
+
+namespace TrainBooking.Application.Abstractions.Repositories;
+
+public interface IUserRepository
+{
+    Task<User?> GetByIdAsync(Guid Id, CancellationToken ct = default);
+    Task<User?> GetByAuth0SubAsync(string Auth0Sub, CancellationToken ct = default);
+    Task AddAsync(User User, CancellationToken ct = default);
+}

--- a/src/TrainBooking.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/src/TrainBooking.Infrastructure/InfrastructureServiceExtensions.cs
@@ -21,6 +21,10 @@ public static class InfrastructureServiceExtensions
 
         services.AddScoped<IUnitOfWork, UnitOfWork>();
         services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<ITrainRepository, TrainRepository>();
+        services.AddScoped<ITripRepository, TripRepository>();
+        services.AddScoped<ITripSeatRepository, TripSeatRepository>();
+        services.AddScoped<IReservationRepository, ReservationRepository>();
 
         return services;
     }

--- a/src/TrainBooking.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/src/TrainBooking.Infrastructure/InfrastructureServiceExtensions.cs
@@ -1,7 +1,9 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using TrainBooking.Application.Abstractions.Repositories;
 using TrainBooking.Infrastructure.Persistence;
+using TrainBooking.Infrastructure.Persistence.Repositories;
 
 namespace TrainBooking.Infrastructure;
 
@@ -16,6 +18,10 @@ public static class InfrastructureServiceExtensions
         services.AddDbContext<AppDbContext>(options =>
             options.UseSqlServer(connectionString, b =>
                 b.MigrationsAssembly("TrainBooking.Migrations")));
+
+        services.AddScoped<IUnitOfWork, UnitOfWork>();
+        services.AddScoped<IUserRepository, UserRepository>();
+
         return services;
     }
 

--- a/src/TrainBooking.Infrastructure/Persistence/Repositories/ReservationRepository.cs
+++ b/src/TrainBooking.Infrastructure/Persistence/Repositories/ReservationRepository.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using TrainBooking.Application.Abstractions.Repositories;
+using TrainBooking.Domain.Reservations;
+using TrainBooking.Domain.Reservations.Enums;
+
+namespace TrainBooking.Infrastructure.Persistence.Repositories;
+
+internal sealed class ReservationRepository(AppDbContext dbContext) : IReservationRepository
+{
+    public async Task<Reservation?> GetByIdAsync(
+        Guid id,
+        CancellationToken ct = default) =>
+            await dbContext.Reservations
+                .Include(r => r.ReservationSeats)
+                .FirstOrDefaultAsync(r => r.Id == id, ct);
+    public async Task<int> CountActiveByUserOnTripAsync(
+        Guid userId,
+        Guid tripId,
+        CancellationToken ct = default) =>
+            await dbContext.Reservations
+                .Where(r => r.UserId == userId
+                    && r.TripId == tripId
+                    && ActiveStatuses.Contains(r.Status))
+                .CountAsync(ct);
+    public async Task<IReadOnlyList<Reservation>> GetExpiredPendingAsync(
+        DateTime now,
+        CancellationToken ct = default) =>
+            await dbContext.Reservations
+                .Include(r => r.ReservationSeats)
+                .Where(r => r.Status == ReservationStatus.Pending
+                    && r.ExpiresAt < now)
+                .ToListAsync(ct);
+    public async Task AddAsync(Reservation reservation, CancellationToken ct = default) =>
+        await dbContext.Reservations.AddAsync(reservation, ct);
+
+    private static readonly ReservationStatus[] ActiveStatuses =
+        [ReservationStatus.Pending, ReservationStatus.Confirmed];
+}

--- a/src/TrainBooking.Infrastructure/Persistence/Repositories/ReservationRepository.cs
+++ b/src/TrainBooking.Infrastructure/Persistence/Repositories/ReservationRepository.cs
@@ -20,7 +20,7 @@ internal sealed class ReservationRepository(AppDbContext dbContext) : IReservati
             await dbContext.Reservations
                 .Where(r => r.UserId == userId
                     && r.TripId == tripId
-                    && ActiveStatuses.Contains(r.Status))
+                    && _activeStatuses.Contains(r.Status))
                 .CountAsync(ct);
     public async Task<IReadOnlyList<Reservation>> GetExpiredPendingAsync(
         DateTime now,
@@ -33,6 +33,6 @@ internal sealed class ReservationRepository(AppDbContext dbContext) : IReservati
     public async Task AddAsync(Reservation reservation, CancellationToken ct = default) =>
         await dbContext.Reservations.AddAsync(reservation, ct);
 
-    private static readonly ReservationStatus[] ActiveStatuses =
+    private static readonly ReservationStatus[] _activeStatuses =
         [ReservationStatus.Pending, ReservationStatus.Confirmed];
 }

--- a/src/TrainBooking.Infrastructure/Persistence/Repositories/TrainRepository.cs
+++ b/src/TrainBooking.Infrastructure/Persistence/Repositories/TrainRepository.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using TrainBooking.Application.Abstractions.Repositories;
+using TrainBooking.Domain.Trains;
+
+namespace TrainBooking.Infrastructure.Persistence.Repositories;
+
+internal sealed class TrainRepository(AppDbContext dbContext) : ITrainRepository
+{
+    public async Task<Train?> GetByIdWithFullStructureAsync(
+        Guid id,
+        CancellationToken ct = default) =>
+            await dbContext.Trains
+                .Include(t => t.Wagons)
+                .ThenInclude(w => w.Seats)
+                .FirstOrDefaultAsync(t => t.Id == id, ct);
+
+    public async Task AddAsync(Train train, CancellationToken ct = default) =>
+        await dbContext.Trains.AddAsync(train, ct);
+}

--- a/src/TrainBooking.Infrastructure/Persistence/Repositories/TripRepository.cs
+++ b/src/TrainBooking.Infrastructure/Persistence/Repositories/TripRepository.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using TrainBooking.Application.Abstractions.Repositories;
+using TrainBooking.Domain.Trips;
+
+namespace TrainBooking.Infrastructure.Persistence.Repositories;
+
+internal sealed class TripRepository(AppDbContext dbContext) : ITripRepository
+{
+    public async Task<Trip?> GetByIdAsync(
+        Guid Id,
+        CancellationToken ct = default) =>
+            await dbContext.Trips.FirstOrDefaultAsync(t => t.Id == Id, ct);
+
+    public async Task AddAsync(
+        Trip trip,
+        CancellationToken ct = default) =>
+            await dbContext.Trips.AddAsync(trip, ct);
+
+}

--- a/src/TrainBooking.Infrastructure/Persistence/Repositories/TripRepository.cs
+++ b/src/TrainBooking.Infrastructure/Persistence/Repositories/TripRepository.cs
@@ -7,9 +7,9 @@ namespace TrainBooking.Infrastructure.Persistence.Repositories;
 internal sealed class TripRepository(AppDbContext dbContext) : ITripRepository
 {
     public async Task<Trip?> GetByIdAsync(
-        Guid Id,
+        Guid id,
         CancellationToken ct = default) =>
-            await dbContext.Trips.FirstOrDefaultAsync(t => t.Id == Id, ct);
+            await dbContext.Trips.FirstOrDefaultAsync(t => t.Id == id, ct);
 
     public async Task AddAsync(
         Trip trip,

--- a/src/TrainBooking.Infrastructure/Persistence/Repositories/TripSeatRepository.cs
+++ b/src/TrainBooking.Infrastructure/Persistence/Repositories/TripSeatRepository.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using TrainBooking.Application.Abstractions.Repositories;
+using TrainBooking.Domain.TripSeats;
+
+namespace TrainBooking.Infrastructure.Persistence.Repositories;
+
+internal sealed class TripSeatRepository(AppDbContext appDbContext) : ITripSeatRepository
+{
+    public async Task<IReadOnlyList<TripSeat>> GetByTripIdAsync(
+        Guid tripId,
+        CancellationToken ct = default) =>
+            await appDbContext.TripSeats.Where(t => t.TripId == tripId).ToListAsync(ct);
+
+    public async Task<IReadOnlyList<TripSeat>> LockByIdsAsync(
+        IReadOnlyCollection<Guid> tripSeatIds,
+        CancellationToken ct = default) =>
+            await appDbContext.TripSeats.Where(ts => tripSeatIds.Contains(ts.SeatId)).ToListAsync(ct);
+
+    public async Task AddRangeAsync(
+        IEnumerable<TripSeat> tripSeats,
+        CancellationToken ct = default) =>
+            await appDbContext.AddRangeAsync(tripSeats, ct);
+}

--- a/src/TrainBooking.Infrastructure/Persistence/Repositories/TripSeatRepository.cs
+++ b/src/TrainBooking.Infrastructure/Persistence/Repositories/TripSeatRepository.cs
@@ -11,6 +11,13 @@ internal sealed class TripSeatRepository(AppDbContext appDbContext) : ITripSeatR
         CancellationToken ct = default) =>
             await appDbContext.TripSeats.Where(t => t.TripId == tripId).ToListAsync(ct);
 
+    /// <summary>
+    /// Acquires update locks on the specified TripSeats for the duration of the current transaction.
+    /// </summary>
+    /// <remarks>
+    /// Must be called inside an active database transaction (BeginTransactionAsync).
+    /// Without a transaction, locks are released immediately after the SELECT completes.
+    /// </remarks>
     public async Task<IReadOnlyList<TripSeat>> LockByIdsAsync(
         IReadOnlyCollection<Guid> tripSeatIds,
         CancellationToken ct = default)

--- a/src/TrainBooking.Infrastructure/Persistence/Repositories/TripSeatRepository.cs
+++ b/src/TrainBooking.Infrastructure/Persistence/Repositories/TripSeatRepository.cs
@@ -13,8 +13,19 @@ internal sealed class TripSeatRepository(AppDbContext appDbContext) : ITripSeatR
 
     public async Task<IReadOnlyList<TripSeat>> LockByIdsAsync(
         IReadOnlyCollection<Guid> tripSeatIds,
-        CancellationToken ct = default) =>
-            await appDbContext.TripSeats.Where(ts => tripSeatIds.Contains(ts.SeatId)).ToListAsync(ct);
+        CancellationToken ct = default)
+    {
+        Guid[] orderedIds = tripSeatIds.OrderBy(id => id).ToArray();
+
+        string sql = $@"
+            SELECT * FROM TripSeats WITH (UPDLOCK, ROWLOCK, HOLDLOCK)
+            WHERE Id IN ({string.Join(",", orderedIds.Select((_, i) => $"{{{i}}}"))})
+            ORDER BY Id";
+
+        return await appDbContext.TripSeats
+            .FromSqlRaw(sql, [.. orderedIds.Cast<object>()])
+            .ToListAsync(ct);
+    }
 
     public async Task AddRangeAsync(
         IEnumerable<TripSeat> tripSeats,

--- a/src/TrainBooking.Infrastructure/Persistence/Repositories/UnitOfWork.cs
+++ b/src/TrainBooking.Infrastructure/Persistence/Repositories/UnitOfWork.cs
@@ -1,0 +1,11 @@
+using TrainBooking.Application.Abstractions.Repositories;
+
+namespace TrainBooking.Infrastructure.Persistence.Repositories;
+
+internal sealed class UnitOfWork(AppDbContext dbContext)
+    : IUnitOfWork
+{
+    private readonly AppDbContext _dbContext = dbContext;
+
+    public Task<int> CommitAsync(CancellationToken ct = default) => _dbContext.SaveChangesAsync(ct);
+}

--- a/src/TrainBooking.Infrastructure/Persistence/Repositories/UserRepository.cs
+++ b/src/TrainBooking.Infrastructure/Persistence/Repositories/UserRepository.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using TrainBooking.Application.Abstractions.Repositories;
+using TrainBooking.Domain.Users;
+
+namespace TrainBooking.Infrastructure.Persistence.Repositories;
+
+internal sealed class UserRepository(AppDbContext dbContext) : IUserRepository
+{
+    private readonly AppDbContext _dbContext = dbContext;
+
+    public Task<User?> GetByIdAsync(
+        Guid Id,
+        CancellationToken ct = default) =>
+            _dbContext.Users.FirstOrDefaultAsync(u => u.Id == Id, ct);
+
+    public Task<User?> GetByAuth0SubAsync(
+        string Auth0Sub,
+        CancellationToken ct = default) =>
+            _dbContext.Users.FirstOrDefaultAsync(u => u.Auth0Sub == Auth0Sub, ct);
+
+    public async Task AddAsync(
+        User User,
+        CancellationToken ct = default) =>
+            await _dbContext.Users.AddAsync(User, ct);
+}

--- a/src/TrainBooking.Infrastructure/TrainBooking.Infrastructure.csproj
+++ b/src/TrainBooking.Infrastructure/TrainBooking.Infrastructure.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\TrainBooking.Domain\TrainBooking.Domain.csproj" />
+      <ProjectReference Include="..\TrainBooking.Application\TrainBooking.Application.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Implements the persistence boundary between Application and Infrastructure: one repository interface per aggregate root in Application, one EF Core implementation per repository in Infrastructure, plus a thin `IUnitOfWork` for transaction commits. Methods are scoped to actual use cases (no generic CRUD), and `TripSeatRepository.LockByIdsAsync` carries the pessimistic-locking SQL the concurrency strategy is built on.

## What's included

### Application - interfaces

- `IUnitOfWork` - single `SaveChangesAsync(ct)` method
- `ITrainRepository` - `GetByIdWithFullStructureAsync` (with `Include` for Wagons → Seats), `AddAsync`
- `IUserRepository` - `GetByIdAsync`, `GetByAuth0SubAsync`, `AddAsync`
- `ITripRepository` - `GetByIdAsync`, `AddAsync`
- `ITripSeatRepository` - `GetByTripIdAsync`, `LockByIdsAsync`, `AddRangeAsync`
- `IReservationRepository` - `GetByIdAsync` (with `Include` for ReservationSeats), `CountActiveByUserOnTripAsync`, `GetExpiredPendingAsync`, `AddAsync`

### Infrastructure: implementations

`internal sealed` classes in `Persistence/Repositories/`, each taking `AppDbContext` via primary constructor. All async methods accept `CancellationToken`.

- `UnitOfWork` - wraps `dbContext.SaveChangesAsync`
- `TrainRepository`, `UserRepository`, `TripRepository`, `ReservationRepository` - straightforward EF Core LINQ
- `TripSeatRepository` - see below

### DI registration

All six (`IUnitOfWork` + 5 repositories) registered as `Scoped` in `AddInfrastructure`. Scope matches `AppDbContext` lifetime.

## Key design notes

### Methods follow use cases, not CRUD

### `Include` belongs to the repository, not the caller

When a method returns a complete aggregate, the repository decides which children to eager-load. `IReservationRepository.GetByIdAsync` always includes `ReservationSeats` because a partially-loaded Reservation can't enforce its invariants. Application code never has to remember to `.Include(...)`.

### Cross-aggregate references are FK-less in code

There is no `Reservation.Trip` or `Reservation.User` navigation property. References across aggregate boundaries go through identifiers (`Reservation.UserId`, `Reservation.TripId`). Per-aggregate boundaries are enforced in code and EF Core configuration; defense-in-depth `OnDelete(Restrict)` foreign keys at the schema level remain a backlog item.

## Pessimistic locking `TripSeatRepository.LockByIdsAsync`

The single most important method in this PR. Concurrency strategy lives or dies on this query.

Implemented via `FromSqlRaw` because EF Core LINQ cannot emit SQL Server table hints.

* `UPDLOCK` - intent-update lock: blocks other writers while still allowing readers
* `ROWLOCK` - forces row-level granularity instead of page or table escalation
* `HOLDLOCK` - holds the lock until the surrounding transaction ends (SERIALIZABLE-style range lock for the selected rows)
* `ORDER BY Id` + `OrderBy(id)` on the input - deterministic lock acquisition order, prevents deadlocks when two concurrent reservation attempts target overlapping seat sets
* The supporting index `IX_TripSeats_TripId_Status` (added in the previous PR) backs the seat lookup before the lock

**Locking only takes effect inside an active transaction.** This method must be called within `dbContext.Database.BeginTransactionAsync(ct)`; without a transaction, locks are released the moment the SELECT completes. Transaction management belongs to the Application-layer command handler (`CreateReservationCommandHandler`, future PR), not to the repository. XMLdoc on the method documents this contract.

## Verification

* `dotnet build --configuration Release` passes for all projects
* No `async`-without-`await` warnings; methods that are single-`await` shorthand are returned directly as `Task<T>`
* All async methods accept and forward `CancellationToken ct = default`