### PR TITLE
feat: add infrastructure event

### DIFF
--- a/src/TrainBooking.Application/ApplicationServiceExtensions.cs
+++ b/src/TrainBooking.Application/ApplicationServiceExtensions.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TrainBooking.Application;
+
+public static class ApplicationServiceExtensions
+{
+    public static IServiceCollection AddApplication(
+        this ServiceCollection services)
+    {
+        services.AddMediatR(cfg =>
+            cfg.RegisterServicesFromAssembly(typeof(ApplicationServiceExtensions).Assembly));
+
+        return services;
+    }
+}

--- a/src/TrainBooking.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/src/TrainBooking.Infrastructure/InfrastructureServiceExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using TrainBooking.Application.Abstractions.Repositories;
 using TrainBooking.Infrastructure.Persistence;
+using TrainBooking.Infrastructure.Persistence.Interceptors;
 using TrainBooking.Infrastructure.Persistence.Repositories;
 
 namespace TrainBooking.Infrastructure;
@@ -15,9 +16,13 @@ public static class InfrastructureServiceExtensions
     {
         string connectionString = configuration.GetConnectionString("DefaultConnection")
             ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
-        services.AddDbContext<AppDbContext>(options =>
-            options.UseSqlServer(connectionString, b =>
-                b.MigrationsAssembly("TrainBooking.Migrations")));
+        services.AddDbContext<AppDbContext>((sp, options) =>
+        {
+            options.UseSqlServer(connectionString, b => b.MigrationsAssembly("TrainBooking.Migrations"));
+            options.AddInterceptors(sp.GetRequiredService<DispatchDomainEventsInterceptor>());
+        });
+
+        services.AddScoped<DispatchDomainEventsInterceptor>();
 
         services.AddScoped<IUnitOfWork, UnitOfWork>();
         services.AddScoped<IUserRepository, UserRepository>();

--- a/src/TrainBooking.Infrastructure/Persistence/Interceptors/DispatchDomainEventsInterceptor.cs
+++ b/src/TrainBooking.Infrastructure/Persistence/Interceptors/DispatchDomainEventsInterceptor.cs
@@ -1,0 +1,112 @@
+using System.Reflection;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using TrainBooking.Application.Abstractions.Messaging;
+using TrainBooking.Domain.Common.DomainEvents;
+using TrainBooking.Domain.Common.Entities;
+
+namespace TrainBooking.Infrastructure.Persistence.Interceptors;
+
+public sealed class DispatchDomainEventsInterceptor(IPublisher publisher)
+        : SaveChangesInterceptor
+{
+    private static readonly Action<AggregateRoot> _clearDomainEventsDelegate;
+
+    /// <summary>
+    /// Initializes a delegate for invoking the hidden domain event removal method
+    /// of <see cref="AggregateRoot"/> using reflection.
+    /// </summary>
+    /// <remarks>
+    /// Used to bypass AggregateRoot encapsulation without changing its public API.
+    ///
+    /// IMPORTANT:
+    /// - Depends on the existence of a method named <c>RemoveDomainEvent</c>.
+    /// - The method must be non-static and have a compatible signature.
+    /// - Any change to the method name or signature will result in a runtime error.
+    ///
+    /// The static constructor executes once when the type is first loaded.
+    ///
+    /// If the method cannot be found, an <see cref="InvalidOperationException"/> is thrown,
+    /// which is considered a critical configuration error.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the <c>RemoveDomainEvent</c> method is not found or cannot be bound.
+    /// </exception>
+    static DispatchDomainEventsInterceptor()
+    {
+        MethodInfo? methodInfo = typeof(AggregateRoot).GetMethod(
+            "RemoveDomainEvent",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException(
+                "Critical error: Cannot finde 'RemoveDomainEvent' method in AggregateRoot.");
+        _clearDomainEventsDelegate = (Action<AggregateRoot>)Delegate.CreateDelegate(
+            typeof(Action<AggregateRoot>),
+            methodInfo);
+    }
+
+    public override async ValueTask<int> SavedChangesAsync(
+        SaveChangesCompletedEventData eventData,
+        int result,
+        CancellationToken ct = default)
+    {
+        if (eventData.Context is null)
+            return result;
+
+        await DispatchDomainEventsAsync(eventData.Context, ct);
+
+        return result;
+    }
+
+    private async Task DispatchDomainEventsAsync(DbContext dbContext, CancellationToken ct)
+    {
+        List<IDomainEvent> processedDomainEvents = [];
+        List<IDomainEvent> unprocessedDomainEvents = GetDomainEvents(dbContext);
+
+        while (unprocessedDomainEvents.Count != 0)
+        {
+            var eventsToDispatch = unprocessedDomainEvents.ToList();
+            ClearDomainEvents(dbContext);
+            await DispatchDomainEventsAsync(eventsToDispatch, ct);
+            processedDomainEvents.AddRange(eventsToDispatch);
+            unprocessedDomainEvents = [.. GetDomainEvents(dbContext).Where(e => !processedDomainEvents.Contains(e))];
+        }
+    }
+
+    private List<AggregateRoot> GetTrackedAggregateRoots(DbContext dbContext) =>
+        [.. dbContext.ChangeTracker
+            .Entries<AggregateRoot>()
+            .Where(x => x.Entity.DomainEvents != null && x.Entity.DomainEvents.Count != 0)
+            .Select(x => x.Entity)];
+
+    private List<IDomainEvent> GetDomainEvents(DbContext dbContext)
+    {
+        List<AggregateRoot> aggregatedRoots = GetTrackedAggregateRoots(dbContext);
+        return [.. aggregatedRoots
+            .SelectMany(x => x.DomainEvents)];
+    }
+
+    private void ClearDomainEvents(DbContext dbContext)
+    {
+        List<AggregateRoot> aggregateRoots = GetTrackedAggregateRoots(dbContext);
+        foreach (AggregateRoot aggregate in aggregateRoots)
+        {
+            _clearDomainEventsDelegate(aggregate);
+        }
+    }
+
+    private async Task DispatchDomainEventsAsync(
+        List<IDomainEvent> domainEvents,
+        CancellationToken ct)
+    {
+        foreach (IDomainEvent domainEvent in domainEvents)
+        {
+            // Create DomainEventNotification<TConcreteEvent> at runtime
+            // because the concrete event type is known only at runtime.
+            Type notificationType = typeof(DomainEventNotification<>)
+                .MakeGenericType(domainEvent.GetType());
+            var notification = (INotification)Activator.CreateInstance(notificationType, domainEvent)!;
+            await publisher.Publish(notification, ct);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR introduces automatic domain event dispatching using MediatR and EF Core interceptors.

## Changes
- Added `ApplicationServiceExtensions` to register MediatR in the Application layer
- Introduced `DispatchDomainEventsInterceptor`
  - Dispatches domain events after `SaveChanges`
  - Supports cascading domain events (events triggered by other events)
  - Uses reflection to access internal domain event cleanup
- Updated `DbContext` configuration:
  - Registered interceptor via DI
  - Attached interceptor to EF Core pipeline

## How it works
- Aggregate roots collect domain events
- After `SaveChanges`, the interceptor:
  1. Extracts all domain events from tracked entities
  2. Publishes them via `IPublisher` (MediatR)
  3. Clears events from aggregates
  4. Repeats until no new events are produced

## Important notes
- Uses reflection to call `AggregateRoot.RemoveDomainEvent`
- This creates a runtime dependency on:
  - method name
  - method signature
- Any change to `AggregateRoot` internals may break this behavior

## Benefits
- Centralized domain event dispatching
- No need to manually publish events in application code
- Supports clean DDD patterns
- Fully integrated with MediatR pipeline