### PR TITLE
feat: add global exception handler

### DIFF
--- a/src/TrainBooking.Api/Middleware/GlobalExceptionHandler.cs
+++ b/src/TrainBooking.Api/Middleware/GlobalExceptionHandler.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace TrainBooking.Api.Middleware;
+
+internal sealed class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> logger)
+    : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken ct)
+    {
+        if (httpContext.Response.HasStarted)
+        {
+            logger.LogWarning("Response has already started, exception handler skipped");
+            return false;  
+        }
+
+        (int statusCode, string title, string detail) = exception switch
+        {
+            OperationCanceledException when ct.IsCancellationRequested
+                => (StatusCodes.Status499ClientClosedRequest, "Request Cancelled", "The client cancelled the request."),
+            _ => (StatusCodes.Status500InternalServerError, "Server Error", "An unexpected error has occurred on the server.")
+        };
+
+        LogLevel logLevel = statusCode >= 500 ? LogLevel.Error : LogLevel.Warning;
+        logger.Log(logLevel, exception, "Unhandled exception: {ExceptionType}", exception.GetType().Name);
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = title,
+            Detail = detail,
+            Type = $"https://httpstatuses.com/{statusCode}",
+            Instance = httpContext.Request.Path 
+        };
+
+        problemDetails.Extensions["traceId"] = httpContext.TraceIdentifier;
+        httpContext.Response.StatusCode = statusCode;
+        httpContext.Response.ContentType = "application/problem+json";
+        await httpContext.Response.WriteAsJsonAsync(problemDetails, ct);
+        return true;
+    }
+}

--- a/src/TrainBooking.Api/Program.cs
+++ b/src/TrainBooking.Api/Program.cs
@@ -1,3 +1,4 @@
+using TrainBooking.Api.Middleware;
 using TrainBooking.Infrastructure;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -6,6 +7,9 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
 builder.Services.AddOpenApi();
+
+builder.Services.AddProblemDetails();
+builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 
 builder.Services.AddInfrastructure(builder.Configuration);
 
@@ -18,7 +22,7 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
-
+app.UseExceptionHandler();
 app.UseAuthorization();
 
 app.MapControllers();


### PR DESCRIPTION
## Summary

Added global exception handling middleware

Introduced a centralized exception handling mechanism using ASP.NET Core `IExceptionHandler`.

## What was added

* `GlobalExceptionHandler` implementing `IExceptionHandler`
* Standardized error responses using `ProblemDetails`
* Logging of unhandled exceptions with appropriate log levels (Warning/Error)
* Special handling for client-cancelled requests (`OperationCanceledException` as 499)

## Configuration changes

* Registered exception handling pipeline via:

  * `AddExceptionHandler<GlobalExceptionHandler>()`
  * `AddProblemDetails()`
* Enabled middleware with `app.UseExceptionHandler()`

## Behavior

* Prevents duplicate responses when HTTP response has already started
* Returns consistent `application/problem+json` responses
* Includes trace correlation via `traceId`
* Maps all unhandled exceptions to a structured API response