### PR TITLE
feat integrate Auth0 authentication with JIT user provisioning

### DIFF
--- a/src/TrainBooking.Api/Constants/HttpContextItemKeys.cs
+++ b/src/TrainBooking.Api/Constants/HttpContextItemKeys.cs
@@ -1,0 +1,6 @@
+namespace TrainBooking.Api.Constants;
+
+public static class HttpContextItemKeys
+{
+    public const string UserId = "internal-user-id";
+}

--- a/src/TrainBooking.Api/Controllers/AuthController.cs
+++ b/src/TrainBooking.Api/Controllers/AuthController.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TrainBooking.Application.Abstractions.Identity;
+
+namespace TrainBooking.Api.Controllers;
+
+[ApiController]
+[Route("api/v1/[controller]")]
+[Authorize]
+public class AuthController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get([FromServices] ICurrentUserService userService) =>
+        Ok(new { userId = userService.UserId });
+}

--- a/src/TrainBooking.Api/Middleware/Auth0JwtBearerOptionsConfigurator.cs
+++ b/src/TrainBooking.Api/Middleware/Auth0JwtBearerOptionsConfigurator.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+namespace TrainBooking.Api.Middleware;
+
+internal sealed class Auth0JwtBearerOptionsConfigurator(IConfiguration configuration)
+    : IConfigureNamedOptions<JwtBearerOptions>
+{
+    public void Configure(JwtBearerOptions options)
+    {
+        options.Authority = $"https://{configuration["Auth0:Domain"]}/";
+        options.Audience = configuration["Auth0:Audience"];
+
+        options.MapInboundClaims = false;
+
+        // Optional for local development
+        if (bool.TryParse(configuration["Auth0:RequireHttpsMetadata"], out bool requireHttps))
+            options.RequireHttpsMetadata = requireHttps;
+
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ClockSkew = TimeSpan.FromMinutes(2),
+            TryAllIssuerSigningKeys = true
+        };
+    }
+
+    public void Configure(string? name, JwtBearerOptions options)
+    {
+        if (name == JwtBearerDefaults.AuthenticationScheme)
+            Configure(options);
+    }
+}

--- a/src/TrainBooking.Api/Middleware/Auth0UserProvisioningMiddleware.cs
+++ b/src/TrainBooking.Api/Middleware/Auth0UserProvisioningMiddleware.cs
@@ -1,0 +1,31 @@
+using TrainBooking.Api.Constants;
+using TrainBooking.Application.Abstractions.Identity;
+
+namespace TrainBooking.Api.Middleware;
+
+internal sealed class Auth0UserProvisioningMiddleware(RequestDelegate next)
+{
+    public async Task InvokeAsync(HttpContext context, IUserResolver resolver)
+    {
+        if (context.User?.Identity?.IsAuthenticated != true)
+        {
+            await next(context);
+            return;
+        }
+
+        string? sub = context.User.FindFirst("sub")?.Value;
+        string? email = context.User.FindFirst("https://api.trainbooking.app/email")?.Value;
+        string? name = context.User.FindFirst("https://api.trainbooking.app/name")?.Value;
+
+        if (sub is null || email is null)
+            throw new InvalidOperationException("Missing required claims in JWT");
+
+        Guid userId = await resolver.ResolveAsync(
+            new Auth0UserInfo(sub, email, name),
+            context.RequestAborted);
+
+        context.Items[HttpContextItemKeys.UserId] = userId;
+
+        await next(context);
+    }
+}

--- a/src/TrainBooking.Api/Middleware/GlobalExceptionHandler.cs
+++ b/src/TrainBooking.Api/Middleware/GlobalExceptionHandler.cs
@@ -14,7 +14,7 @@ internal sealed class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> log
         if (httpContext.Response.HasStarted)
         {
             logger.LogWarning("Response has already started, exception handler skipped");
-            return false;  
+            return false;
         }
 
         (int statusCode, string title, string detail) = exception switch
@@ -33,7 +33,7 @@ internal sealed class GlobalExceptionHandler(ILogger<GlobalExceptionHandler> log
             Title = title,
             Detail = detail,
             Type = $"https://httpstatuses.com/{statusCode}",
-            Instance = httpContext.Request.Path 
+            Instance = httpContext.Request.Path
         };
 
         problemDetails.Extensions["traceId"] = httpContext.TraceIdentifier;

--- a/src/TrainBooking.Api/Program.cs
+++ b/src/TrainBooking.Api/Program.cs
@@ -1,4 +1,5 @@
 using TrainBooking.Api.Middleware;
+using TrainBooking.Application;
 using TrainBooking.Infrastructure;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -12,6 +13,7 @@ builder.Services.AddProblemDetails();
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 
 builder.Services.AddInfrastructure(builder.Configuration);
+builder.Services.AddApplication();
 
 WebApplication app = builder.Build();
 

--- a/src/TrainBooking.Api/Program.cs
+++ b/src/TrainBooking.Api/Program.cs
@@ -1,5 +1,8 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using TrainBooking.Api.Middleware;
+using TrainBooking.Api.Service;
 using TrainBooking.Application;
+using TrainBooking.Application.Abstractions.Identity;
 using TrainBooking.Infrastructure;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -15,6 +18,15 @@ builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 builder.Services.AddInfrastructure(builder.Configuration);
 builder.Services.AddApplication();
 
+builder.Services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer();
+
+builder.Services.ConfigureOptions<Auth0JwtBearerOptionsConfigurator>();
+
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();
+
 WebApplication app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -25,8 +37,9 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 app.UseExceptionHandler();
+app.UseAuthentication();
 app.UseAuthorization();
-
+app.UseMiddleware<Auth0UserProvisioningMiddleware>();
 app.MapControllers();
 
 app.Run();

--- a/src/TrainBooking.Api/Service/CurrentUserService.cs
+++ b/src/TrainBooking.Api/Service/CurrentUserService.cs
@@ -1,0 +1,17 @@
+using TrainBooking.Api.Constants;
+using TrainBooking.Application.Abstractions.Identity;
+
+namespace TrainBooking.Api.Service;
+
+internal sealed class CurrentUserService(IHttpContextAccessor accessor)
+    : ICurrentUserService
+{
+    public Guid? UserId
+    {
+        get
+        {
+            object? value = accessor.HttpContext?.Items[HttpContextItemKeys.UserId];
+            return value as Guid?;
+        }
+    }
+}

--- a/src/TrainBooking.Api/TrainBooking.Api.csproj
+++ b/src/TrainBooking.Api/TrainBooking.Api.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <UserSecretsId>0e7cf268-b61a-4d16-ae24-aa723e8518a7</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <UserSecretsId>4f5cde48-e63c-4e72-9e97-17babe477cdd</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TrainBooking.Api/appsettings.json
+++ b/src/TrainBooking.Api/appsettings.json
@@ -29,8 +29,9 @@
     "RedisConnection": "localhost:6379"
   },
   "Auth0": {
-    "Domain": "your-tenant.eu.auth0.com",
-    "Audience": "https://train-booking-api"
+    "Domain": "demian-trainbooking.eu.auth0.com",
+    "Audience": "https://api.trainbooking.app",
+    "ClaimsNamespace": "https://trainbooking.app/"
   },
   "DomainSettings": {
     "ReservationTtlMinutes": 15,

--- a/src/TrainBooking.Application/Abstractions/Commands/CommandHandler.cs
+++ b/src/TrainBooking.Application/Abstractions/Commands/CommandHandler.cs
@@ -44,8 +44,13 @@ public abstract class CommandHandler<TCommand, TResponse>(IUnitOfWork unitOfWork
 {
     protected readonly IUnitOfWork _unitOfWork = unitOfWork;
 
-    public async Task<Result<TResponse>> Handle(TCommand request, CancellationToken ct) =>
-        await HandleAsync(request, ct);
+    public async Task<Result<TResponse>> Handle(TCommand request, CancellationToken ct)
+    {
+        Result<TResponse> result = await HandleAsync(request, ct);
+        if (result.IsSuccess)
+            await _unitOfWork.CommitAsync(ct);
+        return result;
+    }
 
     /// <summary>
     /// Processes the given command asynchronously and returns a result.

--- a/src/TrainBooking.Application/Abstractions/Identity/Auth0UserInfo.cs
+++ b/src/TrainBooking.Application/Abstractions/Identity/Auth0UserInfo.cs
@@ -1,0 +1,3 @@
+namespace TrainBooking.Application.Abstractions.Identity;
+
+public sealed record Auth0UserInfo(string Sub, string Email, string? FullName);

--- a/src/TrainBooking.Application/Abstractions/Identity/ICurrentUserService.cs
+++ b/src/TrainBooking.Application/Abstractions/Identity/ICurrentUserService.cs
@@ -1,0 +1,6 @@
+namespace TrainBooking.Application.Abstractions.Identity;
+
+public interface ICurrentUserService
+{
+    Guid? UserId { get; }
+}

--- a/src/TrainBooking.Application/Abstractions/Identity/IUserResolver.cs
+++ b/src/TrainBooking.Application/Abstractions/Identity/IUserResolver.cs
@@ -1,0 +1,6 @@
+namespace TrainBooking.Application.Abstractions.Identity;
+
+public interface IUserResolver
+{
+    Task<Guid> ResolveAsync(Auth0UserInfo userInfo, CancellationToken ct);
+}

--- a/src/TrainBooking.Application/ApplicationAssemblyMarker.cs
+++ b/src/TrainBooking.Application/ApplicationAssemblyMarker.cs
@@ -1,0 +1,3 @@
+namespace TrainBooking.Application;
+
+public sealed class ApplicationAssemblyMarker;

--- a/src/TrainBooking.Application/ApplicationServiceExtensions.cs
+++ b/src/TrainBooking.Application/ApplicationServiceExtensions.cs
@@ -1,3 +1,4 @@
+using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace TrainBooking.Application;
@@ -5,10 +6,12 @@ namespace TrainBooking.Application;
 public static class ApplicationServiceExtensions
 {
     public static IServiceCollection AddApplication(
-        this ServiceCollection services)
+        this IServiceCollection services)
     {
         services.AddMediatR(cfg =>
-            cfg.RegisterServicesFromAssembly(typeof(ApplicationServiceExtensions).Assembly));
+            cfg.RegisterServicesFromAssembly(typeof(ApplicationAssemblyMarker).Assembly));
+
+        services.AddValidatorsFromAssembly(typeof(ApplicationAssemblyMarker).Assembly);
 
         return services;
     }

--- a/src/TrainBooking.Application/Users/Commands/CreateUser/CreateUserCommand.cs
+++ b/src/TrainBooking.Application/Users/Commands/CreateUser/CreateUserCommand.cs
@@ -1,0 +1,8 @@
+using TrainBooking.Application.Abstractions.Commands;
+
+namespace TrainBooking.Application.Users.Commands.CreateUser;
+
+public sealed record CreateUserCommand(
+    string Auth0Sub,
+    string Email,
+    string? FullName) : ICommand<Guid>;

--- a/src/TrainBooking.Application/Users/Commands/CreateUser/CreateUserCommandHandler.cs
+++ b/src/TrainBooking.Application/Users/Commands/CreateUser/CreateUserCommandHandler.cs
@@ -1,0 +1,39 @@
+using FluentValidation;
+using FluentValidation.Results;
+using TrainBooking.Application.Abstractions.Commands;
+using TrainBooking.Application.Abstractions.Repositories;
+using TrainBooking.Domain.Common.Results;
+using TrainBooking.Domain.Users;
+
+namespace TrainBooking.Application.Users.Commands.CreateUser;
+
+internal sealed class CreateUserCommandHandler(
+    IUserRepository userRepository,
+    IValidator<CreateUserCommand> validator,
+    IUnitOfWork unitOfWork) : CommandHandler<CreateUserCommand, Guid>(unitOfWork)
+{
+    private readonly IUserRepository _userRepository = userRepository;
+    private readonly IValidator<CreateUserCommand> _validator = validator;
+    protected override async Task<Result<Guid>> HandleAsync(
+        CreateUserCommand req,
+        CancellationToken ct)
+    {
+        ValidationResult validation = await _validator.ValidateAsync(req, ct);
+        if (!validation.IsValid)
+        {
+            string message = string.Join(
+                "; ",
+                validation.Errors.Select(e => $"{e.PropertyName}: {e.ErrorMessage}"));
+            return Error.Validation("Users.Validation", message);
+        }
+
+        User? existing = await _userRepository.GetByAuth0SubAsync(req.Auth0Sub, ct);
+        if (existing is not null)
+            return existing.Id;
+
+        var user = User.Create(req.Auth0Sub, req.Email, req.FullName);
+        await _userRepository.AddAsync(user, ct);
+
+        return user.Id;
+    }
+}

--- a/src/TrainBooking.Application/Users/Commands/CreateUser/CreateUserCommandValidator.cs
+++ b/src/TrainBooking.Application/Users/Commands/CreateUser/CreateUserCommandValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+
+namespace TrainBooking.Application.Users.Commands.CreateUser;
+
+public sealed class CreateUserCommandValidator : AbstractValidator<CreateUserCommand>
+{
+    public CreateUserCommandValidator()
+    {
+        RuleFor(x => x.Auth0Sub)
+            .NotEmpty()
+            .MaximumLength(255);
+
+        RuleFor(x => x.Email)
+            .NotEmpty()
+            .EmailAddress()
+            .MaximumLength(320);
+
+        RuleFor(x => x.FullName)
+            .MaximumLength(255)
+            .When(x => x.FullName is not null);
+    }
+}

--- a/src/TrainBooking.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/src/TrainBooking.Infrastructure/InfrastructureServiceExtensions.cs
@@ -1,10 +1,12 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using TrainBooking.Application.Abstractions.Identity;
 using TrainBooking.Application.Abstractions.Repositories;
 using TrainBooking.Infrastructure.Persistence;
 using TrainBooking.Infrastructure.Persistence.Interceptors;
 using TrainBooking.Infrastructure.Persistence.Repositories;
+using TrainBooking.Infrastructure.Services;
 
 namespace TrainBooking.Infrastructure;
 
@@ -30,6 +32,9 @@ public static class InfrastructureServiceExtensions
         services.AddScoped<ITripRepository, TripRepository>();
         services.AddScoped<ITripSeatRepository, TripSeatRepository>();
         services.AddScoped<IReservationRepository, ReservationRepository>();
+
+        services.AddMemoryCache();
+        services.AddScoped<IUserResolver, UserResolver>();
 
         return services;
     }

--- a/src/TrainBooking.Infrastructure/Services/UserResolver.cs
+++ b/src/TrainBooking.Infrastructure/Services/UserResolver.cs
@@ -1,0 +1,35 @@
+using MediatR;
+using Microsoft.Extensions.Caching.Memory;
+using TrainBooking.Application.Abstractions.Identity;
+using TrainBooking.Application.Abstractions.Repositories;
+using TrainBooking.Application.Users.Commands.CreateUser;
+using TrainBooking.Domain.Common.Results;
+using TrainBooking.Domain.Users;
+
+namespace TrainBooking.Infrastructure.Services;
+
+internal sealed class UserResolver(
+    IMemoryCache cache,
+    IUserRepository userRepository,
+    ISender sender) : IUserResolver
+{
+    public async Task<Guid> ResolveAsync(Auth0UserInfo userInfo, CancellationToken ct)
+    {
+        if (cache.TryGetValue(userInfo.Sub, out Guid cachedId))
+            return cachedId;
+
+        User? existing = await userRepository.GetByAuth0SubAsync(userInfo.Sub, ct);
+        if (existing is not null)
+        {
+            cache.Set(userInfo.Sub, existing.Id, TimeSpan.FromMinutes(20));
+            return existing.Id;
+        }
+
+        Result<Guid> result = await sender.Send(new CreateUserCommand(userInfo.Sub, userInfo.Email, userInfo.FullName), ct);
+        if (result.IsFailure)
+            throw new InvalidOperationException("Cannot create new user");
+
+        cache.Set(userInfo.Sub, result.Value, TimeSpan.FromMinutes(20));
+        return result.Value;
+    }
+}

--- a/src/TrainBooking.Migrations/Program.cs
+++ b/src/TrainBooking.Migrations/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -7,7 +8,13 @@ using TrainBooking.Infrastructure.Persistence;
 
 HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 
-builder.Services.AddInfrastructure(builder.Configuration);
+builder.Configuration.AddUserSecrets<Program>();
+
+string connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
+
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(connectionString, b => b.MigrationsAssembly("TrainBooking.Migrations")));
 
 using IHost host = builder.Build();
 

--- a/src/TrainBooking.Migrations/appsettings.json
+++ b/src/TrainBooking.Migrations/appsettings.json
@@ -3,5 +3,8 @@
     "MinimumLevel": {
       "Default": "Information"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": ""
   }
 }


### PR DESCRIPTION
## Summary

Wires Auth0 as the API's authentication provider and adds a just-in-time user provisioning pipeline. On every authenticated request, the JWT is validated, the corresponding internal `User` aggregate is resolved (or created on first-time login), and its internal `Guid` is exposed to handlers via `ICurrentUserService`. Application-layer handlers stay decoupled from `HttpContext` and from Auth0 specifics.

## What's included

### JWT validation
* **`Auth0JwtBearerOptionsConfigurator`** implementing `IConfigureNamedOptions<JwtBearerOptions>` - configures `Authority`, `Audience`, and `TokenValidationParameters` from `IConfiguration`. Explicit validation flags (`ValidateIssuer`/`Audience`/`Lifetime`/`IssuerSigningKey`), `ClockSkew` tightened from default 5min to 2min, optional `RequireHttpsMetadata` override for local dev.
* **`MapInboundClaims = false`** - keeps original JWT claim names (`sub`, `email`) instead of remapping to SAML-style URIs. Critical for downstream code that reads claims by their canonical names.

### User provisioning
* **`IUserResolver` / `UserResolver`** - resolves Auth0 `sub` to an internal `Guid` using a three-tier lookup: `IMemoryCache` to `IUserRepository` to `CreateUserCommand` via MediatR. Idempotent on concurrent calls for the same user (cache + handler-level idempotency check).
* **`Auth0UserInfo`** - DTO carrying `(Sub, Email, FullName)` from claims into the resolver. Lives in `Application/Abstractions/Identity/`.
* **`Auth0UserProvisioningMiddleware`** - reads claims from `HttpContext.User` after JWT validation, builds `Auth0UserInfo`, calls the resolver, stores the resulting `Guid` in `HttpContext.Items` under a known key. Skips silently on anonymous requests.

### Application-layer access
* **`ICurrentUserService` / `CurrentUserService`** - abstraction over `HttpContext.Items` so Application handlers and other consumers can read the current `Guid` without depending on `HttpContext`. Implementation lives in the Api project and uses `IHttpContextAccessor`.
* **`HttpContextItemKeys`** - single constant class for the items key, avoiding magic strings.

### Test endpoint
* **`AuthController`** - `GET /api/v1/auth` with `[Authorize]`, returns `{ userId }`. Smoke-test target for the full pipeline.

### DI wiring (`Program.cs`)
* `AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer()`
* `ConfigureOptions<Auth0JwtBearerOptionsConfigurator>()`
* `AddHttpContextAccessor()` + `AddScoped<ICurrentUserService, CurrentUserService>()`
* `IMemoryCache` and `IUserResolver` registered in `AddInfrastructure`
* Pipeline order: `UseAuthentication`, `UseAuthorization`, `UseMiddleware<Auth0UserProvisioningMiddleware>`, `MapControllers`

## Design decisions

**Resolver as a separate service, not inline middleware logic.** Keeps the middleware thin (HttpContext-only concerns) and the provisioning logic reusable from non-HTTP contexts (background jobs, integration tests, future SignalR hubs).

**`Auth0UserInfo` DTO over loose parameters.** Adding a future claim (role, organization) means adding a property, not changing every signature in the chain.

**`ICurrentUserService` over direct `HttpContext.Items` access.** Application handlers shouldn't know about HTTP. The service mocks easily in tests.

**`IMemoryCache` with 20-minute absolute TTL.** Simple per-process cache; the cached value (internal `Guid`) is immutable for a given Auth0 `sub`, so staleness is a non-concern. Distributed Redis caching is deferred.

**JWT `sub` as primary external identifier, internal `Guid` as PK.** Aligns with [ADR-0002](./docs/adr/0002-user-internal-guid-with-auth0-sub-unique.md).

## What's not in this PR (backlog)

* **Cache stampede protection** in `UserResolver` - N concurrent first-time requests for the same user trigger N parallel `CreateUserCommand` sends. Handler-level idempotency check + DB unique constraint prevent corruption, but produce N-1 noisy `SqlException 2627`s in the worst case. Solve with `SemaphoreSlim`-per-key or `LazyCache`.
* **`Auth0:ClaimsNamespace` from configuration** - middleware currently hardcodes the namespace. Trivial to extract to `IConfiguration["Auth0:ClaimsNamespace"]`. First followup PR.
* **Auth0 user sync** - local cache is lazy and eventually consistent with Auth0 (email/name changes don't propagate until next refresh). Webhook-driven sync from Auth0 is on the backlog.
* **Distributed cache (Redis)** for the resolver - current `IMemoryCache` is per-process; behind multiple instances each will resolve independently on first request.
* **Pipeline Behaviors** for cross-cutting concerns (validation, logging, transaction management) - currently each command handler invokes its validator manually. See trade-off 4 in README.

## Testing

Smoke-tested end-to-end via Postman:

1. Obtained access token from Auth0 via Resource Owner Password Grant against test SPA application.
2. `GET /api/v1/auth` with `Authorization: Bearer <token>` returned 200 with valid `userId` Guid.
3. Verified row in `Users` table via SSMS - `Auth0Sub`, `Email`, `FullName`, `CreatedAt`, `LastSyncedAt` populated correctly.
4. Subsequent calls return the same `userId` from cache without DB hit.

## Auth0 dashboard configuration required

These are not code changes but part of the deployment contract:

* **API created** in Auth0 with `Identifier` matching `Auth0:Audience` in `appsettings.json`.
* **Post-Login Action** deployed and attached to the Login Flow, adding `email` and `name` to the access token under a custom namespace matching `Auth0:ClaimsNamespace`.
* **Default Audience** set in tenant `Settings to General to API Authorization Settings` to the API's identifier.
* **Default Directory** set to `Username-Password-Authentication` (required for Password Grant flow used in local testing).
* **SPA application** registered, authorized for the API, with Password Grant enabled in advanced settings.
* **Database connection** enabled for the SPA application.

## Reviewer notes

* `Auth0JwtBearerOptionsConfigurator` lives in `Middleware/` though it's technically a DI-time options configurator, not middleware. Folder name is loose; consider renaming to `Configuration/` later.
* `AuthController` returns the current user's internal `Guid` without exposing Auth0 `sub` - deliberate: the `sub` is implementation detail of the identity provider, callers should consume the internal id.
* The middleware throws on missing `sub` or `email` claims. Falls into the global exception handler as 500 - acceptable signal for misconfigured Auth0, not expected for legitimate JWTs.