### PR TITLE
FIX: Remove AddMediatR from migration main

### DIFF
--- a/src/TrainBooking.Migrations/Program.cs
+++ b/src/TrainBooking.Migrations/Program.cs
@@ -3,8 +3,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using TrainBooking.Application;
-using TrainBooking.Infrastructure;
 using TrainBooking.Infrastructure.Persistence;
 
 HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
@@ -13,9 +11,6 @@ builder.Configuration.AddUserSecrets<Program>();
 
 string connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
     ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
-
-builder.Services.AddMediatR(cfg =>
-    cfg.RegisterServicesFromAssembly(typeof(ApplicationAssemblyMarker).Assembly));
 
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlServer(connectionString, b => b.MigrationsAssembly("TrainBooking.Migrations")));


### PR DESCRIPTION
## Summary

Brings the full local development stack under a single `docker compose up`. API and migrations now build and run in containers, communicate with mssql and redis via the compose-managed network, and wire up in the correct order - migrations run as a one-shot job that must complete before the API starts.

This unblocks new contributors (no more "set up SQL Server, configure user secrets, run migrations manually, then `dotnet run`") and gives a baseline for future production-style deployment.

## What's included

### API Dockerfile (`src/TrainBooking.Api/Dockerfile`)

Replaces the VS-generated multi-stage Dockerfile with a simpler two-stage version:

* `aspnet:10.0` as `base` - non-root user via `$APP_UID`, listens on `http://+:8080`.
* `sdk:10.0` as `build` - copies `src/`, restores, publishes Release.
* Final stage copies the published output from `build` and sets the entrypoint.

Listens on HTTP only inside the container; HTTPS termination is a reverse-proxy concern, not a per-service concern. Removed the redundant `publish` stage from the VS template - `build` stage already produces the publish output.

### Migrations Dockerfile (`src/TrainBooking.Migrations/Dockerfile`)

New file. Same two-stage pattern but uses `runtime:10.0` (not `aspnet:10.0`) - the migrations runner is a console app, doesn't need ASP.NET Core, smaller image.

## Backlog

* Healthcheck на mssql + condition: service_healthy in migrations.depends_on.
* Persistent volume for DataProtection-Keys (warning in api logs).
* May be ASPNETCORE_ENVIRONMENT=Development in env api service