### PR TITLE
Develop

### DIFF
--- a/src/TrainBooking.Api/Contracts/Reservations/CreateReservationRequest.cs
+++ b/src/TrainBooking.Api/Contracts/Reservations/CreateReservationRequest.cs
@@ -1,0 +1,5 @@
+namespace TrainBooking.Api.Contracts.Reservations;
+
+public sealed record CreateReservationRequest(
+    Guid TripId,
+    IReadOnlyCollection<Guid> TripSeatIds);

--- a/src/TrainBooking.Api/Controllers/AuthController.cs
+++ b/src/TrainBooking.Api/Controllers/AuthController.cs
@@ -7,7 +7,7 @@ namespace TrainBooking.Api.Controllers;
 [ApiController]
 [Route("api/v1/[controller]")]
 [Authorize]
-public class AuthController : ControllerBase
+public sealed class AuthController : ControllerBase
 {
     [HttpGet]
     public IActionResult Get([FromServices] ICurrentUserService userService) =>

--- a/src/TrainBooking.Api/Controllers/ReservationsController.cs
+++ b/src/TrainBooking.Api/Controllers/ReservationsController.cs
@@ -11,7 +11,7 @@ namespace TrainBooking.Api.Controllers;
 [ApiController]
 [Authorize]
 [Route("api/v1/[controller]")]
-public class ReservationsController(IMediator mediator) : ControllerBase
+public sealed class ReservationsController(ISender mediator) : ControllerBase
 {
     [HttpPost]
     public async Task<IActionResult> Create(

--- a/src/TrainBooking.Api/Controllers/ReservationsController.cs
+++ b/src/TrainBooking.Api/Controllers/ReservationsController.cs
@@ -15,13 +15,14 @@ public sealed class ReservationsController(ISender mediator) : ControllerBase
 {
     [HttpPost]
     public async Task<IActionResult> Create(
-        [FromBody] CreateReservationRequest request)
+        [FromBody] CreateReservationRequest request,
+        CancellationToken ct = default)
     {
         var command = new CreateReservationCommand(
             request.TripId,
             request.TripSeatIds);
 
-        Result<CreateReservationResult> result = await mediator.Send(command);
+        Result<CreateReservationResult> result = await mediator.Send(command, ct);
 
         return result.ToActionResult();
     }

--- a/src/TrainBooking.Api/Controllers/ReservationsController.cs
+++ b/src/TrainBooking.Api/Controllers/ReservationsController.cs
@@ -1,0 +1,28 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using TrainBooking.Api.Contracts.Reservations;
+using TrainBooking.Api.Extensions;
+using TrainBooking.Application.Reservations.Commands.CreateReservation;
+using TrainBooking.Domain.Common.Results;
+
+namespace TrainBooking.Api.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/v1/[controller]")]
+public class ReservationsController(IMediator mediator) : ControllerBase
+{
+    [HttpPost]
+    public async Task<IActionResult> Create(
+        [FromBody] CreateReservationRequest request)
+    {
+        var command = new CreateReservationCommand(
+            request.TripId,
+            request.TripSeatIds);
+
+        Result<CreateReservationResult> result = await mediator.Send(command);
+
+        return result.ToActionResult();
+    }
+}

--- a/src/TrainBooking.Api/Extensions/ResultExtension.cs
+++ b/src/TrainBooking.Api/Extensions/ResultExtension.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Mvc;
+using TrainBooking.Domain.Common.Results;
+
+namespace TrainBooking.Api.Extensions;
+
+internal static class ResultExtension
+{
+    public static IActionResult ToActionResult<T>(this Result<T> result)
+        => result.IsSuccess
+            ? new OkObjectResult(result.Value)
+            : MapError(result.Error!);
+
+    public static IActionResult ToActionResult(this Result result)
+        => result.IsSuccess
+            ? new NoContentResult()
+            : MapError(result.Error!);
+
+    private static ObjectResult MapError(Error error)
+    {
+        int statusCode = error.Type switch
+        {
+            ErrorType.NotFound => StatusCodes.Status404NotFound,
+            ErrorType.Unauthorized => StatusCodes.Status401Unauthorized,
+            ErrorType.Forbidden => StatusCodes.Status403Forbidden,
+            ErrorType.Conflict => StatusCodes.Status409Conflict,
+            ErrorType.BadRequest => StatusCodes.Status400BadRequest,
+            ErrorType.TooManyRequests => StatusCodes.Status429TooManyRequests,
+            ErrorType.Internal => StatusCodes.Status500InternalServerError,
+            _ => StatusCodes.Status400BadRequest
+        };
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = statusCode,
+            Title = error.Type.ToString(),
+            Detail = error.Message,
+            Type = $"https://httpstatuses.com/{statusCode}"
+        };
+
+        problemDetails.Extensions["errorCode"] = error.Code;
+
+        return new ObjectResult(problemDetails) { StatusCode = statusCode };
+    }
+}

--- a/src/TrainBooking.Api/appsettings.json
+++ b/src/TrainBooking.Api/appsettings.json
@@ -33,9 +33,5 @@
     "Audience": "https://api.trainbooking.app",
     "ClaimsNamespace": "https://trainbooking.app/"
   },
-  "DomainSettings": {
-    "ReservationTtlMinutes": 15,
-    "MaxSeatsPerReservation": 4
-  },
   "AllowedHosts": "*"
 }

--- a/src/TrainBooking.Application/Abstractions/Repositories/IDbTransaction.cs
+++ b/src/TrainBooking.Application/Abstractions/Repositories/IDbTransaction.cs
@@ -1,0 +1,7 @@
+namespace TrainBooking.Application.Abstractions.Repositories;
+
+public interface IDbTransaction : IAsyncDisposable
+{
+    Task CommitAsync(CancellationToken ct = default);
+    Task RollbackAsync(CancellationToken ct = default);
+}

--- a/src/TrainBooking.Application/Abstractions/Repositories/IUnitOfWork.cs
+++ b/src/TrainBooking.Application/Abstractions/Repositories/IUnitOfWork.cs
@@ -3,4 +3,5 @@ namespace TrainBooking.Application.Abstractions.Repositories;
 public interface IUnitOfWork
 {
     Task<int> CommitAsync(CancellationToken ct = default);
+    Task<IDbTransaction> BeginTransactionAsync(CancellationToken ct = default);
 }

--- a/src/TrainBooking.Application/Reservations/Commands/CreateReservation/CreateReservationCommand.cs
+++ b/src/TrainBooking.Application/Reservations/Commands/CreateReservation/CreateReservationCommand.cs
@@ -1,0 +1,12 @@
+using TrainBooking.Application.Abstractions.Commands;
+
+namespace TrainBooking.Application.Reservations.Commands.CreateReservation;
+
+public sealed record CreateReservationCommand(
+    Guid TripId,
+    IReadOnlyCollection<Guid> TripSeatIds) : ICommand<CreateReservationResult>;
+
+public sealed record CreateReservationResult(
+    Guid ReservationId,
+    decimal TotalPrice,
+    DateTime ExpiresAt);

--- a/src/TrainBooking.Application/Reservations/Commands/CreateReservation/CreateReservationCommandHandler.cs
+++ b/src/TrainBooking.Application/Reservations/Commands/CreateReservation/CreateReservationCommandHandler.cs
@@ -1,0 +1,105 @@
+using FluentValidation;
+using FluentValidation.Results;
+using TrainBooking.Application.Abstractions.Commands;
+using TrainBooking.Application.Abstractions.Identity;
+using TrainBooking.Application.Abstractions.Repositories;
+using TrainBooking.Domain.Common.Results;
+using TrainBooking.Domain.Reservations;
+using TrainBooking.Domain.Trips;
+using TrainBooking.Domain.TripSeats;
+using TrainBooking.Domain.TripSeats.Enums;
+
+namespace TrainBooking.Application.Reservations.Commands.CreateReservation;
+
+internal sealed class CreateReservationCommandHandler(
+    ICurrentUserService currentUser,
+    ITripRepository tripRepository,
+    ITripSeatRepository tripSeatRepository,
+    IReservationRepository reservationRepository,
+    IValidator<CreateReservationCommand> validator,
+    TimeProvider timeProvider,
+    IUnitOfWork unitOfWork)
+    : CommandHandler<CreateReservationCommand, CreateReservationResult>(unitOfWork)
+{
+    private readonly ICurrentUserService _currentUser = currentUser;
+    private readonly ITripRepository _tripRepository = tripRepository;
+    private readonly ITripSeatRepository _tripSeatRepository = tripSeatRepository;
+    private readonly IReservationRepository _reservationRepository = reservationRepository;
+    private readonly IValidator<CreateReservationCommand> _validator = validator;
+    private readonly TimeProvider _timeProvider = timeProvider;
+
+    protected override async Task<Result<CreateReservationResult>> HandleAsync(
+        CreateReservationCommand request,
+        CancellationToken ct)
+    {
+        ValidationResult validation = await _validator.ValidateAsync(request, ct);
+        if (!validation.IsValid)
+        {
+            string message = string.Join(
+                "; ",
+                validation.Errors.Select(e => $"{e.PropertyName}: {e.ErrorMessage}"));
+            return Error.Validation("Reservations.Validation", message);
+        }
+
+        Guid? userId = _currentUser.UserId;
+        if (userId is null)
+            return Error.Unauthorized(
+                "Reservations.NoAuthenticatedUser",
+                "Authenticated user required to create a reservation.");
+
+        await using IDbTransaction tx = await _unitOfWork.BeginTransactionAsync(ct);
+
+        Trip? trip = await _tripRepository.GetByIdAsync(request.TripId, ct);
+        if (trip is null)
+            return Error.NotFound(
+                "Reservations.TripNotFound",
+                $"Trip '{request.TripId}' was not found.");
+
+        IReadOnlyCollection<TripSeat> lockedSeats =
+            await _tripSeatRepository.LockByIdsAsync(request.TripSeatIds, ct);
+
+        if (lockedSeats.Count != request.TripSeatIds.Count)
+        {
+            HashSet<Guid> foundIds = [.. lockedSeats.Select(s => s.Id)];
+            IEnumerable<Guid> missingIds = request.TripSeatIds.Where(id => !foundIds.Contains(id));
+            return Error.NotFound(
+                "Reservations.SeatsNotFound",
+                $"Trip seats not found: {string.Join(", ", missingIds)}.");
+        }
+
+        IReadOnlyCollection<Guid> unavailableIds =
+            [.. lockedSeats
+                .Where(s => s.Status != TripSeatStatus.Available)
+                .Select(s => s.Id)];
+
+        if (unavailableIds.Count > 0)
+            return Error.Conflict(
+                "Reservations.SeatsNotAvailable",
+                $"Trip seats already reserved or sold: {string.Join(", ", unavailableIds)}.");
+
+        Result<Reservation> reservationResult = Reservation.Create(
+            request.TripId,
+            userId.Value,
+            trip.DepartureTime,
+            lockedSeats,
+            _timeProvider);
+
+        if (reservationResult.IsFailure)
+            return reservationResult.Error!;
+
+        Reservation reservation = reservationResult.Value;
+
+        foreach (TripSeat seat in lockedSeats)
+            seat.Reserve();
+
+        await _reservationRepository.AddAsync(reservation, ct);
+
+        await _unitOfWork.CommitAsync(ct);
+        await tx.CommitAsync(ct);
+
+        return new CreateReservationResult(
+            reservation.Id,
+            reservation.TotalPrice,
+            reservation.ExpiresAt);
+    }
+}

--- a/src/TrainBooking.Application/Reservations/Commands/CreateReservation/CreateReservationCommandValidator.cs
+++ b/src/TrainBooking.Application/Reservations/Commands/CreateReservation/CreateReservationCommandValidator.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+using TrainBooking.Domain.Reservations;
+
+namespace TrainBooking.Application.Reservations.Commands.CreateReservation;
+
+public sealed class CreateReservationCommandValidator
+    : AbstractValidator<CreateReservationCommand>
+{
+    public CreateReservationCommandValidator()
+    {
+        RuleFor(x => x.TripId)
+            .NotEmpty();
+        RuleFor(x => x.TripSeatIds)
+            .NotEmpty()
+            .Must(BeWithinReservationLimit).WithMessage("Reservation must contain between 1 and 4 trip seats.")
+            .Must(BeUnique).WithMessage("Trip seat IDs must be unique within a reservation.");
+
+        RuleForEach(x => x.TripSeatIds)
+            .NotEmpty().WithMessage("Trip seat ID cannot be empty.");
+    }
+
+    private static bool BeWithinReservationLimit(IReadOnlyCollection<Guid> ids) =>
+        ids.Count is >= ReservationPolicy.MinSeats and <= ReservationPolicy.MaxSeats;
+
+    private static bool BeUnique(IReadOnlyCollection<Guid> ids) =>
+        ids.Distinct().Count() == ids.Count;
+}

--- a/src/TrainBooking.Domain/Reservations/Errors/ReservationErrors.cs
+++ b/src/TrainBooking.Domain/Reservations/Errors/ReservationErrors.cs
@@ -6,14 +6,14 @@ public static class ReservationErrors
 {
     public static Error NoSeatSelected() =>
         Error.Validation("reservation.no_seat_selected", "No seat selected. At least one seat must be selected.");
-    public static Error TooManySeatsSelected(int seatCount) =>
-        Error.Validation("reservation.too_many_seats_selected", $"Too many seats selected. Seat count: {seatCount}. Maximum allowed is 4.");
+    public static Error TooManySeatsSelected(int seatCount, int maxSeatCount) =>
+        Error.Validation("reservation.too_many_seats_selected", $"Too many seats selected. Seat count: {seatCount}. Maximum allowed is {maxSeatCount}.");
     public static Error TripAlreadyDeparted(DateTime tripDepartureTime) =>
         Error.Validation("reservation.trip_already_departed", $"Trip has already departed. TripDepartureTime: {tripDepartureTime}.");
     public static Error CannotConfirmExpired(DateTime expiresAt) =>
         Error.Conflict("reservation.cannot_confirm_expired", $"Cannot confirm reservation. Reservation expired at: {expiresAt}.");
-    public static Error CannotCancelWithinDepartureWindow(DateTime tripDepartureTime, int requiredHours) =>
-        Error.Conflict("reservation.cannot_cancel_within_departure_window", $"Cannot cancel reservation within {requiredHours} hours of trip departure. TripDepartureTime: {tripDepartureTime}.");
+    public static Error CannotCancelWithinDepartureWindow(TimeSpan minTimeBeforeDeparture) =>
+        Error.Conflict("reservation.cannot_cancel_within_departure_window", $"Cannot cancel reservation within {minTimeBeforeDeparture.TotalHours} hours of trip departure.");
     public static Error CannotExpireNotYetExpired(DateTime now, DateTime expiresAt) =>
         Error.Conflict("reservation.cannot_expire_not_yet_expired", $"Cannot expire reservation. Current time: {now}. Reservation expires at: {expiresAt}.");
     public static Error AlreadyConfirmed() =>
@@ -24,4 +24,6 @@ public static class ReservationErrors
         Error.Conflict("reservation.already_expired", "Reservation has already expired.");
     public static Error ReservationNotPending() =>
         Error.Validation("reservation.not_pending", "Reservation is not in pending status.");
+    public static Error SeatsFromDifferentTrips() =>
+        Error.Conflict("reservation.this_seats_is_invalid_for_this_trip", "Cannot confirm reservation. Invalid seat");
 }

--- a/src/TrainBooking.Domain/Reservations/Reservation.cs
+++ b/src/TrainBooking.Domain/Reservations/Reservation.cs
@@ -8,7 +8,7 @@ using TrainBooking.Domain.TripSeats;
 
 namespace TrainBooking.Domain.Reservations;
 
-public class Reservation : AggregateRoot
+public sealed class Reservation : AggregateRoot
 {
     public Guid TripId { get; private init; }
     public Guid UserId { get; private init; }
@@ -54,18 +54,23 @@ public class Reservation : AggregateRoot
         Guard.Against.Empty(userId);
         Guard.Against.Null(tripSeats);
 
-        if (tripSeats.Count == 0)
+        if (tripSeats.Count < ReservationPolicy.MinSeats)
             return ReservationErrors.NoSeatSelected();
 
-        if (tripSeats.Count > 4)
-            return ReservationErrors.TooManySeatsSelected(tripSeats.Count);
+        if (tripSeats.Count > ReservationPolicy.MaxSeats)
+            return ReservationErrors.TooManySeatsSelected(
+                tripSeats.Count,
+                ReservationPolicy.MaxSeats);
+
+        if (tripSeats.Any(ts => ts.TripId != tripId))
+            return ReservationErrors.SeatsFromDifferentTrips();
 
         DateTime now = timeProvider.GetUtcNow().UtcDateTime;
         if (tripDepartureTime <= now)
             return ReservationErrors.TripAlreadyDeparted(tripDepartureTime);
 
         var reservationSeats = new List<ReservationSeat>();
-        DateTime expiresAt = now.AddMinutes(15);
+        DateTime expiresAt = now + ReservationPolicy.Ttl;
         decimal totalPrice = tripSeats.Sum(ts => ts.Price);
         var reservationId = Guid.CreateVersion7();
 
@@ -112,10 +117,11 @@ public class Reservation : AggregateRoot
             return pendingResult;
 
         DateTime now = timeProvider.GetUtcNow().UtcDateTime;
-        double hoursUntilDeparture = (TripDepartureTime - now).TotalHours;
-        const int REQUIRED_HOURS = 24;
-        if (hoursUntilDeparture < REQUIRED_HOURS)
-            return ReservationErrors.CannotCancelWithinDepartureWindow(TripDepartureTime, REQUIRED_HOURS);
+        TimeSpan timeUntilDeparture = TripDepartureTime - now;
+        TimeSpan timeBeforeDeparture = ReservationPolicy.MinTimeBeforeDepartureForCancellation;
+
+        if (timeUntilDeparture < timeBeforeDeparture)
+            return ReservationErrors.CannotCancelWithinDepartureWindow(timeBeforeDeparture);
 
         Status = ReservationStatus.Cancelled;
         AddDomainEvent(new ReservationCancelledDomainEvent(Id));

--- a/src/TrainBooking.Domain/Reservations/ReservationPolicy.cs
+++ b/src/TrainBooking.Domain/Reservations/ReservationPolicy.cs
@@ -1,0 +1,9 @@
+namespace TrainBooking.Domain.Reservations;
+
+public static class ReservationPolicy
+{
+    public const int MinSeats = 1;
+    public const int MaxSeats = 4;
+    public static readonly TimeSpan Ttl = TimeSpan.FromMinutes(15);
+    public static readonly TimeSpan MinTimeBeforeDepartureForCancellation = TimeSpan.FromHours(24);
+}

--- a/src/TrainBooking.Infrastructure/Persistence/Repositories/EfCoreDbTransaction.cs
+++ b/src/TrainBooking.Infrastructure/Persistence/Repositories/EfCoreDbTransaction.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore.Storage;
+using TrainBooking.Application.Abstractions.Repositories;
+
+namespace TrainBooking.Infrastructure.Persistence.Repositories;
+
+internal sealed class EfCoreDbTransaction(IDbContextTransaction inner) : IDbTransaction
+{
+    private readonly IDbContextTransaction _inner = inner;
+
+    public Task CommitAsync(CancellationToken ct = default) => _inner.CommitAsync(ct);
+
+    public Task RollbackAsync(CancellationToken ct = default) => _inner.RollbackAsync(ct);
+
+    public ValueTask DisposeAsync() => _inner.DisposeAsync();
+}

--- a/src/TrainBooking.Infrastructure/Persistence/Repositories/UnitOfWork.cs
+++ b/src/TrainBooking.Infrastructure/Persistence/Repositories/UnitOfWork.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore.Storage;
 using TrainBooking.Application.Abstractions.Repositories;
 
 namespace TrainBooking.Infrastructure.Persistence.Repositories;
@@ -5,7 +6,11 @@ namespace TrainBooking.Infrastructure.Persistence.Repositories;
 internal sealed class UnitOfWork(AppDbContext dbContext)
     : IUnitOfWork
 {
-    private readonly AppDbContext _dbContext = dbContext;
+    public Task<int> CommitAsync(CancellationToken ct = default) => dbContext.SaveChangesAsync(ct);
 
-    public Task<int> CommitAsync(CancellationToken ct = default) => _dbContext.SaveChangesAsync(ct);
+    public async Task<IDbTransaction> BeginTransactionAsync(CancellationToken ct = default)
+    {
+        IDbContextTransaction inner = await dbContext.Database.BeginTransactionAsync(ct);
+        return new EfCoreDbTransaction(inner);
+    }
 }


### PR DESCRIPTION
## Summary

Implements the keystone feature of the system: creating a reservation for one or more trip seats. This is the most complex write operation in the project because it combines transactional pessimistic locking, domain invariants, validation, and granular error-to-HTTP mapping.

Path:
`POST /api/v1/reservations`
=> `CreateReservationCommand` (MediatR)
=> handler with explicit transaction
=> `Reservation.Create` (domain factory)
=> persistence

## What's included

### Domain - `Reservation` aggregate and supporting types

* **`Reservation`** aggregate with private constructors, factory method `Create(...)` returning `Result<Reservation>`, state transitions through guarded methods (`Confirm`, `Cancel`, `Expire`), and a private `EnsurePending` switch for centralized status validation.

* **`ReservationStatus`** enum: `Pending -> Confirmed | Cancelled | Expired`.

* **`ReservationSeat`** child entity with `PriceSnapshot`. Locks the price at reservation time so later trip price changes don't affect existing reservations.

* **`ReservationPolicy`** static class as the single source of truth for:

  * `MinSeats` (1)
  * `MaxSeats` (4)
  * `Ttl` (15 min)
  * `MinTimeBeforeDepartureForCancellation` (24 hours)

  Domain invariants live in code, not in `appsettings.json`.

* **`ReservationErrors`** static factories for all domain-level errors with `snake_case` codes (`reservation.no_seat_selected`, `reservation.seats_from_different_trips`, etc.) and contextual messages.

* **Domain events**:

  * `ReservationCreatedDomainEvent`
  * `ReservationConfirmedDomainEvent`
  * `ReservationCancelledDomainEvent`
  * `ReservationExpiredDomainEvent`

  Raised inside aggregate methods and published by `DispatchDomainEventsInterceptor` after successful `SaveChangesAsync`.

### Application - command, validator, handler

* **`CreateReservationCommand(Guid TripId, IReadOnlyCollection<Guid> TripSeatIds) : ICommand<CreateReservationResult>`**

  No `UserId` in the payload. It is resolved from `ICurrentUserService` (ambient identity context), preventing UserId spoofing at the API surface.

* **`CreateReservationResult(Guid ReservationId, decimal TotalPrice, DateTime ExpiresAt)`**

  Richer than a bare `Guid`. Clients usually need `TotalPrice` for display and `ExpiresAt` for countdown timers, so both are returned in one round-trip.

* **`CreateReservationCommandValidator`**

  FluentValidation rules:

  * `TripId.NotEmpty`
  * `TripSeatIds` count between `ReservationPolicy.MinSeats` and `MaxSeats`
  * no duplicates
  * no empty Guids

* **`CreateReservationCommandHandler`** core flow:

  1. Validate command shape
  2. Resolve current user
  3. Open explicit transaction
  4. Load `Trip`
  5. Lock `TripSeats` using `UPDLOCK + ROWLOCK + HOLDLOCK` via `LockByIdsAsync` with deterministic `ORDER BY Id`
  6. Verify requested IDs exist
  7. Verify seats are available
  8. Call `Reservation.Create(...)`
  9. Mark seats as `Reserved`
  10. Save and commit transaction

### Infrastructure - transaction abstraction

* **`IDbTransaction`** interface in Application exposing:

  * `CommitAsync`
  * `RollbackAsync`
  * `IAsyncDisposable`

  Application does not depend on EF Core transaction types.

* **`EfCoreDbTransaction`**

  Internal Infrastructure wrapper around EF Core transactions.

* **`IUnitOfWork.BeginTransactionAsync`**

  Added to the existing Unit of Work abstraction.

### API - controller, request/response, error mapping

* **`ReservationsController`** at `api/v1/reservations` with `[Authorize]`

  * thin controller
  * dispatches through `ISender`
  * supports request cancellation
  * sealed

* **`CreateReservationRequest`**

  Separate API contract isolated from Application CQRS models.

* **`ResultExtensions`**

  Maps `Result` and `Result<T>` to RFC 7807 `ProblemDetails`.

  Mapping:

  * `Validation` => 400
  * `Unauthorized` => 401
  * `Forbidden` => 403
  * `NotFound` => 404
  * `Conflict` => 409
  * `TooManyRequests` => 429
  * `Internal` => 500

  Both `error.Code` and `error.Message` are propagated to the client.

## Design decisions

### No `UserId` in command payload

Identity is ambient context, not request data.
The handler resolves it through `ICurrentUserService` using validated JWT claims. This makes UserId spoofing structurally impossible.

### Domain invariants inside `Reservation.Create`

The aggregate validates:

* empty `tripId`
* empty `userId`
* no seats selected
* too many seats
* seats from different trips
* trip already departed

Database-state checks stay in the handler.

### Pessimistic locking instead of optimistic concurrency

Seat booking is a high-contention scenario.
The chosen approach:

`UPDLOCK + ROWLOCK + HOLDLOCK`

ensures:

* first lock wins
* no double booking
* immediate conflict response instead of retry storms

### Deterministic `ORDER BY Id`

Prevents deadlocks when concurrent requests attempt to reserve overlapping seat sets.

### Explicit transaction in handler

Reservation creation requires:

* lock acquisition
* state transitions
* persistence

inside one transaction boundary.

### `Reservation.TotalPrice` calculated from snapshots

`TotalPrice` is calculated from `ReservationSeats.PriceSnapshot` after seat snapshots are created. This guarantees consistency if future pricing logic changes.

### RFC 7807 everywhere

Both:

* `GlobalExceptionHandler`
* `ResultExtensions`

return standardized `ProblemDetails`.

### `ISender` over `IMediator`

The controller only sends commands and queries. It does not publish events.

### `internal sealed` for `EfCoreDbTransaction`

Infrastructure implementation detail only. Not exposed outside Infrastructure.

## What's NOT in this PR

* Polly retry for SQL deadlocks (`SqlException 1205`)
* Background expiration of pending reservations
* `Idempotency-Key` support
* Limit for active pending reservations per user
* Structured unavailable-seats response DTO
* Integration tests with Testcontainers
* `GET /api/v1/reservations/{id}` endpoint

## Testing

Verified manually through Postman and docker-compose stack.

### Scenarios

1. Happy path
   2 seats available => reservation created successfully.

2. Non-existent seat ID
   Returns 404 and transaction rollback.

3. Seat already reserved
   Returns 409 conflict.

4. Too many seats
   Validator returns 400.

5. Trip already departed
   Domain returns validation failure.

6. Race condition
   10 concurrent requests for the same seat:

   * 1 success
   * 9 conflicts

   Confirms pessimistic locking works correctly.

## Reviewer notes

* The most critical part of this PR is `LockByIdsAsync`.

* Removing:

  * `UPDLOCK`
  * `ROWLOCK`
  * `HOLDLOCK`
  * deterministic `ORDER BY Id`

  can reintroduce double-booking or deadlocks.

* Handler order matters:

  * trip load
  * lock
  * existence check
  * availability check
  * domain create
  * state transition
  * save
  * commit

* `Reservation.TotalPrice` must continue being calculated from final seat snapshots.

* The 24-hour cancellation window is a business rule and should be validated with product requirements before changes.
