### PR TITLE
feat: add CLI-based database seeding

### DIFF
--- a/TrainBooking.slnx
+++ b/TrainBooking.slnx
@@ -13,8 +13,9 @@
     <Project Path="src/TrainBooking.Migrations/TrainBooking.Migrations.csproj">
       <BuildDependency Project="src/TrainBooking.Infrastructure/TrainBooking.Infrastructure.csproj" />
     </Project>
+    <Project Path="src/TrainBooking.Seed/TrainBooking.Seed.csproj" />
   </Folder>
   <Folder Name="/tests/">
-    <Project Path="tests/TrainBooking.Tests/TrainBooking.Tests.csproj" />
+    <Project Path="tests/TrainBooking.Domain.Tests/TrainBooking.Domain.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/TrainBooking.Domain/Common/Results/Result.cs
+++ b/src/TrainBooking.Domain/Common/Results/Result.cs
@@ -12,7 +12,7 @@ public class Result : ResultBase
     private Result(bool isSuccess, Error? error)
         : base(isSuccess, error) { }
 
-    public static Result Success() => new(true, null);
+    public static Result Success() => new(true, Error.None);
     public static Result Failure(Error error) => new(false, error);
 
     /// <summary>

--- a/src/TrainBooking.Seed/DataFactory.cs
+++ b/src/TrainBooking.Seed/DataFactory.cs
@@ -1,0 +1,80 @@
+using TrainBooking.Domain.Common.Results;
+using TrainBooking.Domain.Trains;
+using TrainBooking.Domain.Trains.ValueObjects;
+using TrainBooking.Domain.Trips;
+using TrainBooking.Domain.TripSeats;
+
+namespace TrainBooking.Seed;
+
+internal sealed class DataFactory(TimeProvider timeProvider)
+{
+    public Train CreateTrain(string name, int wagonCount, int seatsPerWagon, SeatClass wagonClass)
+    {
+        var train = Train.Create(name);
+
+        for (int wagonNumber = 1; wagonNumber <= wagonCount; wagonNumber++)
+        {
+            Result addWagon = train.AddWagon(wagonNumber, wagonClass);
+            ThrowIfFailure(addWagon, $"add wagon {wagonNumber}");
+
+            for (int seatNumber = 1; seatNumber <= seatsPerWagon; seatNumber++)
+            {
+                Result addSeat = train.AddSeatToWagon(wagonNumber, seatNumber);
+                ThrowIfFailure(addSeat, $"add seat {seatNumber} to wagon {wagonNumber}");
+            }
+        }
+
+        return train;
+    }
+
+    public Trip CreateTrip(
+        Guid trainId,
+        string origin,
+        string destination,
+        DateTime departure,
+        TimeSpan duration)
+    {
+        Result<Trip> result = Trip.Create(
+            trainId,
+            origin,
+            destination,
+            departure,
+            departure + duration,
+            timeProvider);
+
+        ThrowIfFailure(result, "create trip");
+        return result.Value;
+    }
+
+    public List<TripSeat> CreateTripSeatsForTrain(Guid tripId, Train train, decimal basePrice)
+    {
+        var tripSeats = new List<TripSeat>();
+
+        foreach (Wagon wagon in train.Wagons)
+        {
+            decimal priceForWagon = wagon.Class.CalculatePrice(basePrice);
+
+            foreach (Seat seat in wagon.Seats)
+            {
+                var tripSeat = TripSeat.Create(tripId, seat.Id, priceForWagon);
+                tripSeats.Add(tripSeat);
+            }
+        }
+
+        return tripSeats;
+    }
+
+    private static void ThrowIfFailure(Result result, string operation)
+    {
+        if (result.IsFailure)
+            throw new InvalidOperationException(
+                $"Seed failed to {operation}: [{result.Error?.Code}] {result.Error?.Message}");
+    }
+
+    private static void ThrowIfFailure<T>(Result<T> result, string operation)
+    {
+        if (result.IsFailure)
+            throw new InvalidOperationException(
+                $"Seed failed to {operation}: [{result.Error?.Code}] {result.Error?.Message}");
+    }
+}

--- a/src/TrainBooking.Seed/Program.cs
+++ b/src/TrainBooking.Seed/Program.cs
@@ -1,0 +1,67 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TrainBooking.Infrastructure.Persistence;
+using TrainBooking.Seed;
+
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+
+builder.Configuration.AddUserSecrets<Program>();
+
+string connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? throw new InvalidOperationException(
+        "Connection string 'DefaultConnection' not found. " +
+        "Set it via user secrets or environment variable.");
+
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlServer(connectionString));
+
+builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddScoped<DataFactory>();
+builder.Services.AddScoped<SeedRunner>();
+
+using IHost host = builder.Build();
+
+SeedAction action = ParseAction(args);
+
+using IServiceScope scope = host.Services.CreateScope();
+ILogger<Program> logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+SeedRunner runner = scope.ServiceProvider.GetRequiredService<SeedRunner>();
+
+try
+{
+    await runner.RunAsync(action);
+    return 0;
+}
+catch (Exception ex)
+{
+    logger.LogError(ex, "Seed operation failed.");
+    return 1;
+}
+
+static SeedAction ParseAction(string[] args)
+{
+    string? actionArg = null;
+
+    for (int i = 0; i < args.Length; i++)
+    {
+        if (args[i] == "--action" && i + 1 < args.Length)
+        {
+            actionArg = args[i + 1];
+            break;
+        }
+    }
+
+    actionArg ??= args.FirstOrDefault();
+
+    if (string.IsNullOrWhiteSpace(actionArg))
+        return SeedAction.Full;
+
+    if (Enum.TryParse<SeedAction>(actionArg, ignoreCase: true, out SeedAction parsed))
+        return parsed;
+
+    throw new ArgumentException(
+        $"Unknown action: '{actionArg}'. Valid values: {string.Join(", ", Enum.GetNames<SeedAction>())}.");
+}

--- a/src/TrainBooking.Seed/SeedCommand.cs
+++ b/src/TrainBooking.Seed/SeedCommand.cs
@@ -1,0 +1,39 @@
+using System.CommandLine;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TrainBooking.Seed;
+
+/// <summary>
+/// Command to seed the database with initial data for the Train Booking application.
+/// </summary>
+internal sealed class SeedCommand : Command
+{
+    public SeedCommand(IServiceProvider serviceProvider)
+        : base("seed", "Database seeding management")
+    {
+        var actionOption = new Option<SeedAction>("--action")
+        {
+            Description = "The seeding action to perform",
+            DefaultValueFactory = (result) => SeedAction.Seed
+        };
+
+        Options.Add(actionOption);
+
+        SetAction(async (result, ct) =>
+        {
+            SeedAction action = result.GetValue(actionOption);
+            SeedRunner? runner = ActivatorUtilities.CreateInstance<SeedRunner>(serviceProvider);
+            await runner.RunAsync(action, ct);
+        });
+    }
+}
+
+/// <summary>
+/// Actions that can be performed by the SeedCommand.
+/// </summary>
+public enum SeedAction
+{
+    Seed,
+    Full,
+    Reset
+}

--- a/src/TrainBooking.Seed/SeedRunner.cs
+++ b/src/TrainBooking.Seed/SeedRunner.cs
@@ -1,0 +1,106 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using TrainBooking.Domain.Trains;
+using TrainBooking.Domain.Trains.ValueObjects;
+using TrainBooking.Domain.Trips;
+using TrainBooking.Domain.TripSeats;
+using TrainBooking.Domain.TripSeats.Enums;
+using TrainBooking.Infrastructure.Persistence;
+
+namespace TrainBooking.Seed;
+
+internal sealed class SeedRunner(
+    AppDbContext dbContext,
+    ILogger<SeedRunner> logger,
+    DataFactory dataFactory,
+    TimeProvider timeProvider)
+{
+    public async Task RunAsync(SeedAction action, CancellationToken ct = default)
+    {
+        logger.LogInformation("Starting seed operation: {Action}", action);
+
+        switch (action)
+        {
+            case SeedAction.Seed:
+                await SeedDataAsync(ct);
+                break;
+            case SeedAction.Full:
+                await FullSeedDataAsync(ct);
+                break;
+            case SeedAction.Reset:
+                await ResetReservationsAsync(ct);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(action), action, $"Unknown seed action: {action}");
+        }
+
+        logger.LogInformation("Seed action completed.");
+    }
+
+    private async Task ResetReservationsAsync(CancellationToken ct)
+    {
+        logger.LogInformation("Resetting reservations and restoring seat availability...");
+
+        await dbContext.Reservations.ExecuteDeleteAsync(ct);
+
+        int updatedRows = await dbContext.TripSeats
+            .ExecuteUpdateAsync(
+                s => s.SetProperty(ts => ts.Status, TripSeatStatus.Available),
+                ct);
+
+        logger.LogInformation(
+            "Reservations cleared, {Count} TripSeats reset to Available.", updatedRows);
+    }
+
+    private async Task FullSeedDataAsync(CancellationToken ct)
+    {
+        logger.LogInformation("Performing full seed operation...");
+
+        await DeleteAllDataAsync(ct);
+        await SeedDataAsync(ct);
+    }
+
+    private async Task DeleteAllDataAsync(CancellationToken ct)
+    {
+        logger.LogInformation("Deleting all data from the database...");
+
+        await dbContext.Reservations.ExecuteDeleteAsync(ct);
+        await dbContext.Trips.ExecuteDeleteAsync(ct);
+        await dbContext.Trains.ExecuteDeleteAsync(ct);
+        await dbContext.TripSeats
+            .ExecuteUpdateAsync(s => s.SetProperty(ts => ts.Status, TripSeatStatus.Available), ct);
+
+        logger.LogInformation("All data deleted and TripSeats reset to Available.");
+    }
+
+    private async Task SeedDataAsync(CancellationToken ct)
+    {
+        logger.LogInformation("Seeding initial data...");
+
+        Train train = dataFactory.CreateTrain(
+            name: "Express Train",
+            wagonCount: 2,
+            seatsPerWagon: 4,
+            wagonClass: SeatClass.SecondClass);
+
+        Trip trip = dataFactory.CreateTrip(
+            trainId: train.Id,
+            origin: "Kyiv",
+            destination: "Lviv",
+            departure: timeProvider.GetUtcNow().UtcDateTime.AddDays(1),
+            duration: TimeSpan.FromHours(8));
+
+        List<TripSeat> tripSeats = dataFactory.CreateTripSeatsForTrain(
+            tripId: trip.Id,
+            train: train,
+            basePrice: 100m);
+
+        dbContext.Trains.Add(train);
+        dbContext.Trips.Add(trip);
+        dbContext.TripSeats.AddRange(tripSeats);
+        await dbContext.SaveChangesAsync(ct);
+
+        logger.LogInformation("Initial data seeding completed.");
+    }
+}

--- a/src/TrainBooking.Seed/TrainBooking.Seed.csproj
+++ b/src/TrainBooking.Seed/TrainBooking.Seed.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>8d9a3bb2-6e2c-4483-89bc-b8a862060b72</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.7" />
+    <PackageReference Include="System.CommandLine" Version="2.0.7" />
+  </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\TrainBooking.Domain\TrainBooking.Domain.csproj" />
+        <ProjectReference Include="..\TrainBooking.Infrastructure\TrainBooking.Infrastructure.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/TrainBooking.Seed/appsettings.json
+++ b/src/TrainBooking.Seed/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information"
+    }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": ""
+  }
+}


### PR DESCRIPTION
## Summary

Introduces a dedicated **seeding project (`TrainBooking.Seed`)** for managing development database data in an isolated and controlled way.

The seeding system supports multiple execution modes and is fully separated from the main application.

## What was added

### Seed project

* Standalone console-style seeding project
* DI configuration with `AppDbContext`, `SeedRunner`, `DataFactory`
* User Secrets–based configuration
* Entry point with CLI argument parsing (`--action`)

---

### Seed execution

`SeedRunner` supports three modes:

* `Seed` - insert initial dataset
* `Full` - wipe DB and reseed
* `Reset` - reset reservations and seat availability

Uses:

* EF Core bulk operations (`ExecuteDelete`, `ExecuteUpdate`)
* structured logging
* cancellation token support

---

### Data generation

`DataFactory` encapsulates domain-based creation of:

* `Train` (wagons + seats)
* `Trip`
* `TripSeat`

All entities are created via **domain factories**, ensuring invariants are respected.

## Design decisions

### Isolation

Seeding is fully isolated from API and Infrastructure to avoid production coupling.

### Domain consistency

All seeded data is created through domain methods, not EF constructors.

### Efficient reset strategy

`Reset` avoids full DB recreation and only resets relevant state.

## Usage

```bash id="seed1"
dotnet run --project TrainBooking.Seed --action Seed
dotnet run --project TrainBooking.Seed --action Full
dotnet run --project TrainBooking.Seed --action Reset
```

## Result

Provides a clean, repeatable and safe way to populate and reset the database for development and testing.
