### PR TITLE
test: add unit and integration tests for reservation flow

### DIFF
--- a/TrainBooking.slnx
+++ b/TrainBooking.slnx
@@ -17,5 +17,6 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/TrainBooking.Domain.Tests/TrainBooking.Domain.Tests.csproj" />
+    <Project Path="tests/TrainBooking.IntegrationTests/TrainBooking.IntegrationTests.csproj" />
   </Folder>
 </Solution>

--- a/tests/TrainBooking.Domain.Tests/Reservations/ReservationCancelTests.cs
+++ b/tests/TrainBooking.Domain.Tests/Reservations/ReservationCancelTests.cs
@@ -1,0 +1,8 @@
+namespace TrainBooking.Domain.Tests.Reservations;
+
+// TO DO: Implement tests for Reservation.Cancel method,
+// covering scenarios such as successful cancellation,
+// cancellation within departure window, and cancellation of already cancelled reservation.
+internal class ReservationCancelTests
+{
+}

--- a/tests/TrainBooking.Domain.Tests/Reservations/ReservationConfirmTests.cs
+++ b/tests/TrainBooking.Domain.Tests/Reservations/ReservationConfirmTests.cs
@@ -1,0 +1,115 @@
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using TrainBooking.Domain.Common.Results;
+using TrainBooking.Domain.Reservations;
+using TrainBooking.Domain.Reservations.Enums;
+using TrainBooking.Domain.Reservations.Errors;
+using TrainBooking.Domain.TripSeats;
+
+namespace TrainBooking.Domain.Tests.Reservations;
+
+public class ReservationConfirmTests
+{
+    private static readonly DateTime _fixedNow = new(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void Confirm_WhenPendingAndNotExpired_ReturnsSuccessAndSetsConfirmedStatus()
+    {
+        FakeTimeProvider timeProvider = SetupFixedTimeProvider();
+        Reservation reservation = CreatePendingReservation(timeProvider);
+
+        Result result = reservation.Confirm(timeProvider);
+
+        result.IsSuccess.Should().BeTrue();
+        reservation.Status.Should().Be(ReservationStatus.Confirmed);
+        reservation.ConfirmedAt.Should().Be(_fixedNow);
+    }
+    [Fact]
+    public void Confirm_WhenAlreadyConfirmed_ReturnsAlreadyConfirmedError()
+    {
+        FakeTimeProvider timeProvider = SetupFixedTimeProvider();
+        Reservation reservation = CreatePendingReservation(timeProvider);
+
+        Result firstResult = reservation.Confirm(timeProvider);
+        Result secondResult = reservation.Confirm(timeProvider);
+
+        secondResult.IsSuccess.Should().BeFalse();
+        secondResult.Error.Should().Be(ReservationErrors.AlreadyConfirmed());
+    }
+    [Fact]
+    public void Confirm_WhenAlreadyCancelled_ReturnsAlreadyCancelledError()
+    {
+        FakeTimeProvider timeProvider = SetupFixedTimeProvider();
+        Reservation reservation = CreatePendingReservation(timeProvider);
+
+        Result cancelResult = reservation.Cancel(timeProvider);
+        cancelResult.IsSuccess.Should().BeTrue();
+
+        Result result = reservation.Confirm(timeProvider);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ReservationErrors.AlreadyCancelled());
+    }
+    [Fact]
+    public void Confirm_WhenExpired_ReturnsCannotConfirmExpiredError()
+    {
+        FakeTimeProvider timeProvider = SetupFixedTimeProvider();
+        Reservation reservation = CreatePendingReservation(timeProvider);
+
+        timeProvider.Advance(TimeSpan.FromMinutes(16));
+
+        Result result = reservation.Confirm(timeProvider);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ReservationErrors.CannotConfirmExpired(reservation.ExpiresAt));
+    }
+
+    [Fact]
+    public void Confirm_WhenAlreadyExpired_ReturnsAlreadyExpiredError()
+    {
+        FakeTimeProvider timeProvider = SetupFixedTimeProvider();
+        Reservation reservation = CreatePendingReservation(timeProvider);
+
+        timeProvider.Advance(TimeSpan.FromMinutes(16));
+
+        Result expireResult = reservation.Expire(timeProvider);
+        expireResult.IsSuccess.Should().BeTrue();
+
+        Result result = reservation.Confirm(timeProvider);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ReservationErrors.AlreadyExpired());
+    }
+
+    // Helpers
+    private static Reservation CreatePendingReservation(FakeTimeProvider timeProvider)
+    {
+        var userId = Guid.NewGuid();
+        var tripId = Guid.NewGuid();
+        DateTime departure = _fixedNow.AddDays(7);
+        List<TripSeat> tripSeats = CreateValidTripSeats(tripId);
+
+        Result<Reservation> result = Reservation.Create(
+            tripId,
+            userId,
+            departure,
+            tripSeats,
+            timeProvider);
+
+        return result.Value;
+
+    }
+    private static List<TripSeat> CreateValidTripSeats(Guid tripId)
+    {
+        return
+        [
+            TripSeat.Create(tripId, Guid.NewGuid(), 100m),
+            TripSeat.Create(tripId, Guid.NewGuid(), 150m)
+        ];
+    }
+    private static FakeTimeProvider SetupFixedTimeProvider()
+    {
+        var fakeTimeProvider = new FakeTimeProvider(_fixedNow);
+        return fakeTimeProvider;
+    }
+}

--- a/tests/TrainBooking.Domain.Tests/Reservations/ReservationExpireTests.cs
+++ b/tests/TrainBooking.Domain.Tests/Reservations/ReservationExpireTests.cs
@@ -1,0 +1,7 @@
+namespace TrainBooking.Domain.Tests.Reservations;
+
+// TO DO: Implement tests for Reservation.Expire method,
+// covering scenarios such as successful expiration and expiration of already expired reservation.
+internal class ReservationExpireTests
+{
+}

--- a/tests/TrainBooking.IntegrationTests/Infrastructure/DatabaseFixture.cs
+++ b/tests/TrainBooking.IntegrationTests/Infrastructure/DatabaseFixture.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using Testcontainers.MsSql;
+using TrainBooking.Infrastructure.Persistence;
+
+namespace TrainBooking.IntegrationTests.Infrastructure;
+
+public class DatabaseFixture : IAsyncLifetime
+{
+    private readonly MsSqlContainer _container = new MsSqlBuilder()
+        .WithPassword("Password_12345!")
+        .Build();
+
+    public string ConnectionString => _container.GetConnectionString() + ";Database=TrainBooking;TrustServerCertificate=true";
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+        await ApplyMigrationsAsync();
+    }
+
+    public async Task DisposeAsync() =>
+        await _container.DisposeAsync();
+
+    private async Task ApplyMigrationsAsync()
+    {
+        DbContextOptions<AppDbContext> options = new DbContextOptionsBuilder<AppDbContext>()
+        .UseSqlServer(ConnectionString, b => b.MigrationsAssembly("TrainBooking.Migrations"))
+        .Options;
+
+        await using var dbContext = new AppDbContext(options);
+        await dbContext.Database.MigrateAsync();
+    }
+
+    public AppDbContext CreateDbContext()
+    {
+        DbContextOptions<AppDbContext> options = new DbContextOptionsBuilder<AppDbContext>()
+        .UseSqlServer(ConnectionString, b => b.MigrationsAssembly("TrainBooking.Migrations"))
+        .Options;
+
+        return new AppDbContext(options);
+    }
+}

--- a/tests/TrainBooking.IntegrationTests/Infrastructure/IntegrationTestCollection.cs
+++ b/tests/TrainBooking.IntegrationTests/Infrastructure/IntegrationTestCollection.cs
@@ -1,0 +1,6 @@
+namespace TrainBooking.IntegrationTests.Infrastructure;
+
+[CollectionDefinition("IntegrationTests")]
+public class IntegrationTestCollection : ICollectionFixture<DatabaseFixture>
+{
+}

--- a/tests/TrainBooking.IntegrationTests/Infrastructure/TestData.cs
+++ b/tests/TrainBooking.IntegrationTests/Infrastructure/TestData.cs
@@ -1,0 +1,84 @@
+using Microsoft.EntityFrameworkCore;
+using TrainBooking.Domain.Common.Results;
+using TrainBooking.Domain.Trains;
+using TrainBooking.Domain.Trains.ValueObjects;
+using TrainBooking.Domain.Trips;
+using TrainBooking.Domain.TripSeats;
+using TrainBooking.Domain.Users;
+using TrainBooking.Infrastructure.Persistence;
+
+namespace TrainBooking.IntegrationTests.Infrastructure;
+
+public sealed record ReservationScenarioData(
+    Guid UserId,
+    Guid TripId,
+    IReadOnlyList<Guid> TripSeatIds,
+    DateTime TripDepartureTime);
+
+public static class TestData
+{
+    public static async Task<ReservationScenarioData> SeedReservationScenarioAsync(
+        DatabaseFixture fixture,
+        int seatsCount = 4,
+        decimal seatPrice = 100.00m,
+        CancellationToken cancellationToken = default)
+    {
+        await using AppDbContext dbContext = fixture.CreateDbContext();
+
+        var train = Train.Create("Test Train");
+
+        const int wagonNumber = 1;
+        train.AddWagon(wagonNumber, SeatClass.SecondClass);
+
+        for (int seatNumber = 1; seatNumber <= seatsCount; seatNumber++)
+            train.AddSeatToWagon(wagonNumber, seatNumber);
+
+        DateTime departure = DateTime.UtcNow.AddDays(7);
+        DateTime arrival = departure.AddHours(8);
+
+        Result<Trip> tripResult = Trip.Create(
+            train.Id,
+            "Kyiv",
+            "Lviv",
+            departure,
+            arrival,
+            TimeProvider.System);
+
+        if (tripResult.IsFailure)
+            throw new InvalidOperationException(
+                $"Failed to create test Trip: {tripResult.Error?.Message}");
+
+        Trip trip = tripResult.Value;
+
+        Seat[] seats = train.Wagons.SelectMany(w => w.Seats).ToArray();
+        TripSeat[] tripSeats = [.. seats.Select(seat => TripSeat.Create(trip.Id, seat.Id, seatPrice))];
+
+        var user = User.Create(
+            auth0Sub: $"auth0|test-{Guid.NewGuid()}",
+            email: "test@example.com",
+            fullName: "Test User");
+
+        dbContext.Trains.Add(train);
+        dbContext.Trips.Add(trip);
+        dbContext.TripSeats.AddRange(tripSeats);
+        dbContext.Users.Add(user);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return new ReservationScenarioData(
+            UserId: user.Id,
+            TripId: trip.Id,
+            TripSeatIds: tripSeats.Select(ts => ts.Id).ToArray(),
+            TripDepartureTime: departure);
+    }
+
+    public static async Task CleanDatabaseAsync(DatabaseFixture fixture, CancellationToken cancellationToken = default)
+    {
+        await using AppDbContext dbContext = fixture.CreateDbContext();
+
+        await dbContext.Reservations.ExecuteDeleteAsync(cancellationToken);
+        await dbContext.TripSeats.ExecuteDeleteAsync(cancellationToken);
+        await dbContext.Trips.ExecuteDeleteAsync(cancellationToken);
+        await dbContext.Trains.ExecuteDeleteAsync(cancellationToken);
+        await dbContext.Users.ExecuteDeleteAsync(cancellationToken);
+    }
+}

--- a/tests/TrainBooking.IntegrationTests/Reservations/CreateReservationCommandHandlerTests.cs
+++ b/tests/TrainBooking.IntegrationTests/Reservations/CreateReservationCommandHandlerTests.cs
@@ -1,0 +1,177 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using TrainBooking.Application;
+using TrainBooking.Application.Abstractions.Identity;
+using TrainBooking.Application.Reservations.Commands.CreateReservation;
+using TrainBooking.Domain.Common.Results;
+using TrainBooking.Domain.Reservations;
+using TrainBooking.Domain.Reservations.Enums;
+using TrainBooking.Domain.TripSeats;
+using TrainBooking.Domain.TripSeats.Enums;
+using TrainBooking.Infrastructure;
+using TrainBooking.Infrastructure.Persistence;
+using TrainBooking.IntegrationTests.Infrastructure;
+
+namespace TrainBooking.IntegrationTests.Reservations;
+
+[Collection("IntegrationTests")]
+public class CreateReservationCommandHandlerTests(DatabaseFixture fixture)
+{
+    [Fact]
+    public async Task Handle_WithValidRequest_CreatesReservationAndReservesSeats()
+    {
+        await TestData.CleanDatabaseAsync(fixture);
+        ReservationScenarioData data = await TestData.SeedReservationScenarioAsync(fixture);
+
+        IServiceProvider services = BuildServiceProvider(data.UserId);
+        ISender mediator = services.GetRequiredService<ISender>();
+
+        var command = new CreateReservationCommand(
+            TripId: data.TripId,
+            TripSeatIds: [.. data.TripSeatIds.Take(2)]);
+
+        Result<CreateReservationResult> result = await mediator.Send(command);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ReservationId.Should().NotBe(Guid.Empty);
+        result.Value.TotalPrice.Should().Be(200m);
+        result.Value.ExpiresAt.Should().BeAfter(DateTime.UtcNow);
+
+        await using AppDbContext verifyContext = fixture.CreateDbContext();
+
+        Reservation? reservation = await verifyContext.Reservations
+            .Include(r => r.ReservationSeats)
+            .SingleOrDefaultAsync(r => r.Id == result.Value.ReservationId);
+
+        reservation.Should().NotBeNull();
+        reservation!.UserId.Should().Be(data.UserId);
+        reservation.TripId.Should().Be(data.TripId);
+        reservation.Status.Should().Be(ReservationStatus.Pending);
+        reservation.TotalPrice.Should().Be(200m);
+        reservation.ReservationSeats.Should().HaveCount(2);
+
+        List<TripSeat> lockedSeats = await verifyContext.TripSeats
+            .Where(ts => data.TripSeatIds.Take(2).Contains(ts.Id))
+            .ToListAsync();
+
+        lockedSeats.Should().HaveCount(2);
+        lockedSeats.Should().AllSatisfy(s => s.Status.Should().Be(TripSeatStatus.Reserved));
+
+        List<TripSeat> stillAvailable = await verifyContext.TripSeats
+            .Where(ts => data.TripSeatIds.Skip(2).Contains(ts.Id))
+            .ToListAsync();
+
+        stillAvailable.Should().AllSatisfy(s => s.Status.Should().Be(TripSeatStatus.Available));
+    }
+
+    [Fact]
+    public async Task Handle_WhenSeatAlreadyReserved_ReturnsSeatsNotAvailableError()
+    {
+        await TestData.CleanDatabaseAsync(fixture);
+        ReservationScenarioData data = await TestData.SeedReservationScenarioAsync(fixture);
+
+        IServiceProvider services = BuildServiceProvider(data.UserId);
+        ISender mediator = services.GetRequiredService<ISender>();
+
+        var firstCommand = new CreateReservationCommand(
+            TripId: data.TripId,
+            TripSeatIds: [data.TripSeatIds[0]]);
+
+        Result<CreateReservationResult> firstResult = await mediator.Send(firstCommand);
+        firstResult.IsSuccess.Should().BeTrue();
+
+        var secondCommand = new CreateReservationCommand(
+            TripId: data.TripId,
+            TripSeatIds: [data.TripSeatIds[0]]);
+
+        Result<CreateReservationResult> secondResult = await mediator.Send(secondCommand);
+
+        secondResult.IsFailure.Should().BeTrue();
+        secondResult.Error!.Code.Should().Be("Reservations.SeatsNotAvailable");
+        secondResult.Error.Type.Should().Be(ErrorType.Conflict);
+
+        await using AppDbContext verifyContext = fixture.CreateDbContext();
+        int count = await verifyContext.Reservations.CountAsync();
+        count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_With10ParallelRequestsForSameSeat_ExactlyOneSucceeds()
+    {
+        await TestData.CleanDatabaseAsync(fixture);
+        ReservationScenarioData data = await TestData.SeedReservationScenarioAsync(fixture);
+
+        Guid contestedSeat = data.TripSeatIds[0];
+
+        const int parallelCount = 10;
+        Task<Result<CreateReservationResult>>[] tasks = [.. Enumerable.Range(0, parallelCount)
+            .Select(_ => RunReservationAsync(data.UserId, data.TripId, contestedSeat))];
+
+        Result<CreateReservationResult>[] results = await Task.WhenAll(tasks);
+
+        int successCount = results.Count(r => r.IsSuccess);
+        int conflictCount = results.Count(r =>
+            r.IsFailure && r.Error!.Code == "Reservations.SeatsNotAvailable");
+
+        successCount.Should().Be(1,
+            "Only one parallel request should reserve the seat");
+        conflictCount.Should().Be(9,
+            "Nine of the remaining requests should receive SeatsNotAvailable from the pessimistic lock");
+
+        await using AppDbContext verifyContext = fixture.CreateDbContext();
+        int reservationCount = await verifyContext.Reservations.CountAsync();
+        reservationCount.Should().Be(1,
+            "double-booking not allowed — pessimistic lock protects against race conditions");
+
+        TripSeat seat = await verifyContext.TripSeats.SingleAsync(ts => ts.Id == contestedSeat);
+        seat.Status.Should().Be(TripSeatStatus.Reserved);
+    }
+
+    private async Task<Result<CreateReservationResult>> RunReservationAsync(
+        Guid userId, Guid tripId, Guid tripSeatId)
+    {
+        IServiceProvider services = BuildServiceProvider(userId);
+        ISender mediator = services.GetRequiredService<ISender>();
+
+        var command = new CreateReservationCommand(
+            TripId: tripId,
+            TripSeatIds: [tripSeatId]);
+
+        return await mediator.Send(command);
+    }
+
+    private IServiceProvider BuildServiceProvider(Guid userId)
+    {
+        var services = new ServiceCollection();
+
+        services.AddDbContext<AppDbContext>(options =>
+            options.UseSqlServer(
+                fixture.ConnectionString,
+                b => b.MigrationsAssembly("TrainBooking.Migrations")));
+
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = fixture.ConnectionString,
+            })
+            .Build();
+
+        services.AddInfrastructure(configuration);
+
+        services.AddApplication();
+
+        services.AddLogging();
+
+        services.AddSingleton(TimeProvider.System);
+
+        ICurrentUserService currentUser = Substitute.For<ICurrentUserService>();
+        currentUser.UserId.Returns(userId);
+        services.AddScoped(_ => currentUser);
+
+        return services.BuildServiceProvider();
+    }
+}

--- a/tests/TrainBooking.IntegrationTests/TrainBooking.IntegrationTests.csproj
+++ b/tests/TrainBooking.IntegrationTests/TrainBooking.IntegrationTests.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\..\src\TrainBooking.Application\TrainBooking.Application.csproj" />
     <ProjectReference Include="..\..\src\TrainBooking.Infrastructure\TrainBooking.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\TrainBooking.Domain\TrainBooking.Domain.csproj" />
+    <ProjectReference Include="..\..\src\TrainBooking.Migrations\TrainBooking.Migrations.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/TrainBooking.IntegrationTests/TrainBooking.IntegrationTests.csproj
+++ b/tests/TrainBooking.IntegrationTests/TrainBooking.IntegrationTests.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="FluentAssertions" Version="8.10.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.11.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TrainBooking.Application\TrainBooking.Application.csproj" />
+    <ProjectReference Include="..\..\src\TrainBooking.Infrastructure\TrainBooking.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\TrainBooking.Domain\TrainBooking.Domain.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Adds the first test coverage to the project: unit tests for the `Reservation` aggregate and integration tests for `CreateReservationCommandHandler` running against a real SQL Server via Testcontainers. The integration suite includes a race-condition test that verifies pessimistic locking under concurrent load.

## What's included

**Unit tests** (`tests/TrainBooking.Domain.Tests/`):
- 8 tests on `Reservation.Create` - covers all validation paths (empty IDs, null collections, seat count limits, seats from different trips, past departure) and the happy path with full state assertions.
- 4 tests on `Reservation.Confirm` - covers state transitions from Pending, Confirmed, Cancelled, and expired-but-still-Pending states.
- Uses `FakeTimeProvider` for deterministic time-based assertions (`ExpiresAt = now + 15min`, expiration windows).

**Integration tests** (`tests/TrainBooking.IntegrationTests/`):
- `DatabaseFixture` - spins up an MSSQL container via Testcontainers, applies migrations, exposes a `DbContext` factory. One container per test run, shared across tests via xUnit `ICollectionFixture`.
- `TestData` - helper that seeds a consistent Train + Wagon + Seats + Trip + TripSeats + User graph using the same domain factory methods as production seed.
- 3 handler tests:
  - **Happy path** - verifies the full pipeline (validation - trip lookup - seat lock - reservation create - status flip - save), including DB state after the call.
  - **Conflict on already-reserved seat** - verifies that the second attempt returns `Reservations.SeatsNotAvailable` and no second reservation is created.
  - **Race condition** - fires 10 parallel `mediator.Send` calls for the same seat and asserts exactly 1 success + 9 conflicts + 1 row in `Reservations`. This is the critical safety net for `LockByIdsAsync`.

## Design decisions

**Domain tests use `FakeTimeProvider` from `Microsoft.Extensions.TimeProvider.Testing`.** All time-dependent assertions are pinned to a fixed `FixedNow`, removing flakiness from real-clock drift.

**Integration tests build a per-test `IServiceProvider`** rather than using a shared one. Each parallel task in the race test gets its own scope and `DbContext`, mirroring production where each HTTP request has its own scope - important because `LockByIdsAsync` only meaningfully locks across separate scopes.

**`ICurrentUserService` is the only mocked dependency in integration tests** (via NSubstitute). Everything else is real: MediatR, validators, EF Core, transactions, the interceptor. The point of an integration test is to exercise the real stack; mocking too much defeats the purpose.

**Migrations are applied at fixture startup**, not per test. Data is cleaned via `TestData.CleanDatabaseAsync` between tests when needed, which is much cheaper than re-applying migrations.

## What's NOT in this PR

Tracked as follow-ups:

- Unit tests for `Reservation.Cancel` (5 scenarios incl. 24-hour cancellation window) and `Reservation.Expire` (3 scenarios). Pattern is established by the existing `Confirm` tests; mechanical to add.
- Unit tests for `CreateReservationCommandValidator`. Low-effort given the validator is small.
- Integration tests for the remaining failure paths of the handler (`TripNotFound`, `SeatsNotFound`, `TripAlreadyDeparted`). The happy path + 2 failure paths already cover the most expensive logic; full matrix can come later.
- Cleanup of the small bug found and fixed in `Result.Success()` deserves its own focused PR if anyone wants to call it out separately.

## Testing

Tests run locally via `dotnet test`. First run pulls the MSSQL Testcontainers image (~500MB, one-time). Subsequent runs complete the full suite in ~30 seconds.

The race-condition test was the most important verification - confirms that `UPDLOCK + ROWLOCK + HOLDLOCK + ORDER BY Id` in `LockByIdsAsync` correctly serializes concurrent reservation attempts for the same seat.

## Reviewer notes

If `LockByIdsAsync` is ever refactored, the race test is the safety net - don't merge changes to that method if it goes red.