### PR TITLE
feat: add confirm reservation

### DIFF
--- a/src/TrainBooking.Api/Controllers/ReservationsController.cs
+++ b/src/TrainBooking.Api/Controllers/ReservationsController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using TrainBooking.Api.Contracts.Reservations;
 using TrainBooking.Api.Extensions;
+using TrainBooking.Application.Reservations.Commands.ConfirmReservation;
 using TrainBooking.Application.Reservations.Commands.CreateReservation;
 using TrainBooking.Domain.Common.Results;
 
@@ -24,6 +25,16 @@ public sealed class ReservationsController(ISender mediator) : ControllerBase
 
         Result<CreateReservationResult> result = await mediator.Send(command, ct);
 
+        return result.ToActionResult();
+    }
+
+    [HttpPost("{reservationId:guid}/confirm")]
+    public async Task<IActionResult> Confirm(
+        [FromRoute] Guid reservationId,
+        CancellationToken ct = default)
+    {
+        var command = new ConfirmReservationCommand(reservationId);
+        Result<ConfirmReservationResult> result = await mediator.Send(command, ct);
         return result.ToActionResult();
     }
 }

--- a/src/TrainBooking.Application/Reservations/Commands/ConfirmReservation/ConfirmReservationCommand.cs
+++ b/src/TrainBooking.Application/Reservations/Commands/ConfirmReservation/ConfirmReservationCommand.cs
@@ -9,4 +9,5 @@ public sealed record ConfirmReservationResult(
     Guid ReservationId,
     Guid TripId,
     IReadOnlyCollection<Guid> TripSeatIds,
-    decimal TotalPrice);
+    decimal TotalPrice,
+    DateTime ConfirmedAt);

--- a/src/TrainBooking.Application/Reservations/Commands/ConfirmReservation/ConfirmReservationCommand.cs
+++ b/src/TrainBooking.Application/Reservations/Commands/ConfirmReservation/ConfirmReservationCommand.cs
@@ -1,0 +1,12 @@
+using TrainBooking.Application.Abstractions.Commands;
+
+namespace TrainBooking.Application.Reservations.Commands.ConfirmReservation;
+
+public sealed record ConfirmReservationCommand(
+    Guid ReservationId) : ICommand<ConfirmReservationResult>;
+
+public sealed record ConfirmReservationResult(
+    Guid ReservationId,
+    Guid TripId,
+    IReadOnlyCollection<Guid> TripSeatIds,
+    decimal TotalPrice);

--- a/src/TrainBooking.Application/Reservations/Commands/ConfirmReservation/ConfirmReservationCommandHandler.cs
+++ b/src/TrainBooking.Application/Reservations/Commands/ConfirmReservation/ConfirmReservationCommandHandler.cs
@@ -19,13 +19,18 @@ internal sealed class ConfirmReservationCommandHandler(
         ConfirmReservationCommand request,
         CancellationToken ct)
     {
-        Guid? user = userService.UserId ??
-            throw new UnauthorizedAccessException("User is not authenticated.");
+        Guid? user = userService.UserId;
+        if (user is null)
+        {
+            return Error.Unauthorized(
+                "Reservations.ConfirmReservation.Unauthorized",
+                "You must be authenticated to confirm a reservation.");
+        }
 
         Reservation? reservation = await reservationRepository.GetByIdAsync(request.ReservationId, ct);
         if (reservation is null)
             return Error.NotFound(
-                "Reservations.ReservationNotFound",
+                "Reservations.ConfirmReservation.ReservationNotFound",
                 $"Reservation '{request.ReservationId}' was not found.");
 
         if (user != reservation.UserId)
@@ -41,16 +46,25 @@ internal sealed class ConfirmReservationCommandHandler(
 
         IReadOnlyCollection<TripSeat> tripSeats = await tripSeatRepository.GetByIdsAsync(tripSeatIds, ct);
 
-        reservation.Confirm(timeProvider);
+        Result confirmResult = reservation.Confirm(timeProvider);
+        if (confirmResult.IsFailure)
+            return confirmResult.Error!;
+
         foreach (TripSeat tripSeat in tripSeats)
-            tripSeat.MarkAsSold();
+        {
+            Result markAsSoldResult = tripSeat.MarkAsSold();
+            if (markAsSoldResult.IsFailure)
+                return markAsSoldResult.Error!;
+        }
+
         await _unitOfWork.CommitAsync(ct);
 
         return new ConfirmReservationResult(
             reservation.Id,
             reservation.TripId,
-            [.. tripSeats.Select(ts => ts.Id)],
-            reservation.TotalPrice
+            tripSeatIds, 
+            reservation.TotalPrice,
+            reservation.ConfirmedAt!.Value
         );
     }
 }

--- a/src/TrainBooking.Application/Reservations/Commands/ConfirmReservation/ConfirmReservationCommandHandler.cs
+++ b/src/TrainBooking.Application/Reservations/Commands/ConfirmReservation/ConfirmReservationCommandHandler.cs
@@ -62,7 +62,7 @@ internal sealed class ConfirmReservationCommandHandler(
         return new ConfirmReservationResult(
             reservation.Id,
             reservation.TripId,
-            tripSeatIds, 
+            tripSeatIds,
             reservation.TotalPrice,
             reservation.ConfirmedAt!.Value
         );

--- a/src/TrainBooking.Application/Reservations/Commands/ConfirmReservation/ConfirmReservationCommandHandler.cs
+++ b/src/TrainBooking.Application/Reservations/Commands/ConfirmReservation/ConfirmReservationCommandHandler.cs
@@ -1,0 +1,56 @@
+using TrainBooking.Application.Abstractions.Commands;
+using TrainBooking.Application.Abstractions.Identity;
+using TrainBooking.Application.Abstractions.Repositories;
+using TrainBooking.Domain.Common.Results;
+using TrainBooking.Domain.Reservations;
+using TrainBooking.Domain.TripSeats;
+
+namespace TrainBooking.Application.Reservations.Commands.ConfirmReservation;
+
+internal sealed class ConfirmReservationCommandHandler(
+    IReservationRepository reservationRepository,
+    ICurrentUserService userService,
+    ITripSeatRepository tripSeatRepository,
+    TimeProvider timeProvider,
+    IUnitOfWork unitOfWork)
+    : CommandHandler<ConfirmReservationCommand, ConfirmReservationResult>(unitOfWork)
+{
+    protected override async Task<Result<ConfirmReservationResult>> HandleAsync(
+        ConfirmReservationCommand request,
+        CancellationToken ct)
+    {
+        Guid? user = userService.UserId ??
+            throw new UnauthorizedAccessException("User is not authenticated.");
+
+        Reservation? reservation = await reservationRepository.GetByIdAsync(request.ReservationId, ct);
+        if (reservation is null)
+            return Error.NotFound(
+                "Reservations.ReservationNotFound",
+                $"Reservation '{request.ReservationId}' was not found.");
+
+        if (user != reservation.UserId)
+        {
+            return Error.Forbidden(
+                "Reservations.ConfirmReservation.Forbidden",
+                "You are not the owner of this reservation.");
+        }
+
+        var tripSeatIds = reservation.ReservationSeats
+            .Select(rs => rs.TripSeatId)
+            .ToList();
+
+        IReadOnlyCollection<TripSeat> tripSeats = await tripSeatRepository.GetByIdsAsync(tripSeatIds, ct);
+
+        reservation.Confirm(timeProvider);
+        foreach (TripSeat tripSeat in tripSeats)
+            tripSeat.MarkAsSold();
+        await _unitOfWork.CommitAsync(ct);
+
+        return new ConfirmReservationResult(
+            reservation.Id,
+            reservation.TripId,
+            [.. tripSeats.Select(ts => ts.Id)],
+            reservation.TotalPrice
+        );
+    }
+}

--- a/src/TrainBooking.Application/Reservations/Commands/ConfirmReservation/ConfirmReservationCommandValidator.cs
+++ b/src/TrainBooking.Application/Reservations/Commands/ConfirmReservation/ConfirmReservationCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace TrainBooking.Application.Reservations.Commands.ConfirmReservation;
+
+public sealed class ConfirmReservationCommandValidator : AbstractValidator<ConfirmReservationCommand>
+{
+    public ConfirmReservationCommandValidator()
+    {
+        RuleFor(x => x.ReservationId)
+            .NotEmpty()
+            .WithMessage("Reservation ID is required.");
+    }
+}

--- a/tests/TrainBooking.IntegrationTests/Reservations/ConfirmReservationCommandHandlerTests.cs
+++ b/tests/TrainBooking.IntegrationTests/Reservations/ConfirmReservationCommandHandlerTests.cs
@@ -82,7 +82,7 @@ public class ConfirmReservationCommandHandlerTests(DatabaseFixture fixture)
 
         Guid reservationId = createResult.Value.ReservationId;
 
-        Guid userIdB = Guid.NewGuid();
+        var userIdB = Guid.NewGuid();
         IServiceProvider servicesUserB = BuildServiceProvider(userIdB);
         ISender mediatorB = servicesUserB.GetRequiredService<ISender>();
 
@@ -115,7 +115,7 @@ public class ConfirmReservationCommandHandlerTests(DatabaseFixture fixture)
         IServiceProvider services = BuildServiceProvider(data.UserId);
         ISender mediator = services.GetRequiredService<ISender>();
 
-        Guid nonExistentReservationId = Guid.NewGuid();
+        var nonExistentReservationId = Guid.NewGuid();
 
         var command = new ConfirmReservationCommand(nonExistentReservationId);
         Result<ConfirmReservationResult> result = await mediator.Send(command);

--- a/tests/TrainBooking.IntegrationTests/Reservations/ConfirmReservationCommandHandlerTests.cs
+++ b/tests/TrainBooking.IntegrationTests/Reservations/ConfirmReservationCommandHandlerTests.cs
@@ -1,0 +1,185 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using TrainBooking.Application;
+using TrainBooking.Application.Abstractions.Identity;
+using TrainBooking.Application.Reservations.Commands.ConfirmReservation;
+using TrainBooking.Application.Reservations.Commands.CreateReservation;
+using TrainBooking.Domain.Common.Results;
+using TrainBooking.Domain.Reservations;
+using TrainBooking.Domain.Reservations.Enums;
+using TrainBooking.Domain.TripSeats;
+using TrainBooking.Domain.TripSeats.Enums;
+using TrainBooking.Infrastructure;
+using TrainBooking.Infrastructure.Persistence;
+using TrainBooking.IntegrationTests.Infrastructure;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace TrainBooking.IntegrationTests.Reservations;
+
+[Collection("IntegrationTests")]
+public class ConfirmReservationCommandHandlerTests(DatabaseFixture fixture)
+{
+    [Fact]
+    public async Task Handle_WithValidRequest_ConfirmsReservationAndMarksSeatsSold()
+    {
+        await TestData.CleanDatabaseAsync(fixture);
+        ReservationScenarioData scenarioData = await TestData.SeedReservationScenarioAsync(fixture);
+        IServiceProvider serviceProvider = BuildServiceProvider(scenarioData.UserId);
+        ISender mediator = serviceProvider.GetRequiredService<ISender>();
+
+        var createCommand = new CreateReservationCommand(
+            TripId: scenarioData.TripId,
+            TripSeatIds: [.. scenarioData.TripSeatIds.Take(2)]);
+
+        Result<CreateReservationResult> createResult = await mediator.Send(createCommand);
+        createResult.IsSuccess.Should().BeTrue("setup must succeed before testing Confirm");
+
+        Guid reservationId = createResult.Value.ReservationId;
+
+        var confirmCommand = new ConfirmReservationCommand(ReservationId: reservationId);
+        Result<ConfirmReservationResult> confirmResult = await mediator.Send(confirmCommand);
+
+        confirmResult.IsSuccess.Should().BeTrue();
+        confirmResult.Value.ReservationId.Should().Be(reservationId);
+        confirmResult.Value.TripId.Should().Be(scenarioData.TripId);
+        confirmResult.Value.TotalPrice.Should().Be(200m);
+        confirmResult.Value.ConfirmedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+
+        await using AppDbContext verifyContext = fixture.CreateDbContext();
+
+        Reservation reservation = await verifyContext.Reservations
+            .SingleAsync(r => r.Id == reservationId);
+
+        reservation.Status.Should().Be(ReservationStatus.Confirmed);
+        reservation.ConfirmedAt.Should().NotBeNull();
+
+        List<TripSeat> soldSeats = await verifyContext.TripSeats
+            .Where(ts => scenarioData.TripSeatIds.Take(2).Contains(ts.Id))
+            .ToListAsync();
+
+        soldSeats.Should().HaveCount(2);
+        soldSeats.Should().AllSatisfy(s => s.Status.Should().Be(TripSeatStatus.Sold));
+    }
+    [Fact]
+    public async Task Handle_WhenCallerIsNotOwner_ReturnsForbidden()
+    {
+        await TestData.CleanDatabaseAsync(fixture);
+        ReservationScenarioData data = await TestData.SeedReservationScenarioAsync(fixture);
+
+        IServiceProvider servicesUserA = BuildServiceProvider(data.UserId);
+        ISender mediatorA = servicesUserA.GetRequiredService<ISender>();
+
+        var createCommand = new CreateReservationCommand(
+            TripId: data.TripId,
+            TripSeatIds: [.. data.TripSeatIds.Take(1)]);
+
+        Result<CreateReservationResult> createResult = await mediatorA.Send(createCommand);
+        createResult.IsSuccess.Should().BeTrue();
+
+        Guid reservationId = createResult.Value.ReservationId;
+
+        Guid userIdB = Guid.NewGuid();
+        IServiceProvider servicesUserB = BuildServiceProvider(userIdB);
+        ISender mediatorB = servicesUserB.GetRequiredService<ISender>();
+
+        var confirmCommand = new ConfirmReservationCommand(reservationId);
+        Result<ConfirmReservationResult> result = await mediatorB.Send(confirmCommand);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Type.Should().Be(ErrorType.Forbidden);
+
+        await using AppDbContext verifyContext = fixture.CreateDbContext();
+
+        Reservation reservation = await verifyContext.Reservations
+            .SingleAsync(r => r.Id == reservationId);
+
+        reservation.Status.Should().Be(ReservationStatus.Pending,
+            "Reservation must remain Pending — Confirm should not have succeeded");
+
+        List<TripSeat> seats = await verifyContext.TripSeats
+            .Where(ts => data.TripSeatIds.Take(1).Contains(ts.Id))
+            .ToListAsync();
+
+        seats.Should().AllSatisfy(s => s.Status.Should().Be(TripSeatStatus.Reserved));
+    }
+    [Fact]
+    public async Task Handle_WhenReservationNotFound_ReturnsNotFoundError()
+    {
+        await TestData.CleanDatabaseAsync(fixture);
+        ReservationScenarioData data = await TestData.SeedReservationScenarioAsync(fixture);
+
+        IServiceProvider services = BuildServiceProvider(data.UserId);
+        ISender mediator = services.GetRequiredService<ISender>();
+
+        Guid nonExistentReservationId = Guid.NewGuid();
+
+        var command = new ConfirmReservationCommand(nonExistentReservationId);
+        Result<ConfirmReservationResult> result = await mediator.Send(command);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Type.Should().Be(ErrorType.NotFound);
+        result.Error.Code.Should().Be("Reservations.ConfirmReservation.ReservationNotFound");
+    }
+    [Fact]
+    public async Task Handle_WhenReservationAlreadyConfirmed_ReturnsConflictError()
+    {
+        await TestData.CleanDatabaseAsync(fixture);
+        ReservationScenarioData data = await TestData.SeedReservationScenarioAsync(fixture);
+
+        IServiceProvider services = BuildServiceProvider(data.UserId);
+        ISender mediator = services.GetRequiredService<ISender>();
+
+        var createCommand = new CreateReservationCommand(
+            TripId: data.TripId,
+            TripSeatIds: [.. data.TripSeatIds.Take(1)]);
+
+        Result<CreateReservationResult> createResult = await mediator.Send(createCommand);
+        createResult.IsSuccess.Should().BeTrue();
+
+        Guid reservationId = createResult.Value.ReservationId;
+
+        var firstConfirm = new ConfirmReservationCommand(reservationId);
+        Result<ConfirmReservationResult> firstResult = await mediator.Send(firstConfirm);
+        firstResult.IsSuccess.Should().BeTrue("first Confirm must succeed");
+
+        var secondConfirm = new ConfirmReservationCommand(reservationId);
+        Result<ConfirmReservationResult> secondResult = await mediator.Send(secondConfirm);
+
+        secondResult.IsFailure.Should().BeTrue();
+        secondResult.Error!.Type.Should().Be(ErrorType.Conflict);
+        secondResult.Error.Code.Should().Be("reservation.already_confirmed");
+    }
+
+    // Could be extracted to a common test base class
+    private IServiceProvider BuildServiceProvider(Guid userId)
+    {
+        var services = new ServiceCollection();
+
+        services.AddDbContext<AppDbContext>(options =>
+            options.UseSqlServer(
+                fixture.ConnectionString,
+                b => b.MigrationsAssembly("TrainBooking.Migrations")));
+
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = fixture.ConnectionString,
+            })
+            .Build();
+
+        services.AddInfrastructure(configuration);
+        services.AddLogging();
+        services.AddApplication();
+        services.AddSingleton(TimeProvider.System);
+
+        ICurrentUserService currentUser = Substitute.For<ICurrentUserService>();
+        currentUser.UserId.Returns(userId);
+        services.AddScoped(_ => currentUser);
+
+        return services.BuildServiceProvider();
+    }
+}


### PR DESCRIPTION
## Summary

Implements - `POST: api/v1/reservations/{id}/confirm`. The next state transition after `Create`. The endpoint takes a reservation from `Pending` to `Confirmed`, marks all associated `TripSeats` as `Sold`, and returns a ticket-shaped payload for client display.

## What's included

- **`ConfirmReservationCommand`** + **`ConfirmReservationResult`** in `Application/Reservations/Commands/ConfirmReservation/`. Command carries only `ReservationId`; identity is resolved from `ICurrentUserService`.
- **`ConfirmReservationCommandValidator`** - single rule (`ReservationId.NotEmpty()`).
- **`ConfirmReservationCommandHandler`**:
  1. Resolve current user (`Error.Unauthorized` if missing).
  2. Load reservation (`Error.NotFound` if absent).
  3. Ownership check (`Error.Forbidden` if caller is not the owner).
  4. Load associated `TripSeats` via `ITripSeatRepository.GetByIdsAsync`.
  5. Call `Reservation.Confirm(timeProvider)` - propagate any domain failure as-is.
  6. Call `TripSeat.MarkAsSold()` on each seat - propagate failures as-is.
  7. Single `SaveChanges` - atomic transition across both aggregates.
- **`ReservationsController.Confirm`** endpoint at `POST {id:guid}/confirm`. Thin: reads ID from route, dispatches via `ISender`, maps through `ResultExtensions`.
- **Integration tests** (`ConfirmReservationCommandHandlerTests`): happy path (verifies status flips and seats become Sold), ownership violation (verifies state unchanged on Forbidden), reservation-not-found, and double-confirm conflict.

## Design decisions

**No explicit transaction.** Unlike `Create`, this handler doesn't need pessimistic locking - it changes two aggregates (Reservation and TripSeats) but a single `SaveChanges` wraps them in an implicit transaction. All-or-nothing semantics are preserved.

**Domain errors propagate as-is.** When `Reservation.Confirm` returns `Failure` (already-confirmed, already-cancelled, expired), the handler returns `result.Error` directly without wrapping. Clients see precise domain codes (`reservation.cannot_confirm_expired`, `reservation.already_confirmed`, etc.) rather than a generic "InvalidState" - better for client-side error handling.

**Ownership is checked in the Application layer, not Domain.** Currently, `Reservation` doesn't know "who is acting on me" - it only enforces state transition invariants. Authorization is a cross-cutting concern handled by the handler with `ICurrentUserService`. If ownership rules grow more complex (admin override, delegation), we'd push this down later.

**Response is "ticket-shaped", not minimal.** Returns the full payload (TripId, TripSeatIds, TotalPrice, ConfirmedAt) rather than just IDs. Confirm is a finalize operation; clients commonly want a complete snapshot for confirmation screens, receipts, or screenshots - analogous to a checkout response that returns the full receipt.

**`TripSeat.MarkAsSold` order matters.** After `Reservation.Confirm` succeeds, marking seats Sold cannot fail under normal operation - they were Reserved (set by the create flow). Any failure here is an invariant violation worth surfacing rather than swallowing, so we propagate the domain error.

## Testing

Manual (Postman):

* Happy path - 200 OK with full payload.
* Forbidden - token from a different user against an existing reservation - 403.
* Not found - random GUID - 404.
* Already confirmed - second Confirm returns 409 with `reservation.already_confirmed`.
